### PR TITLE
Add ESLint, Prettier, and VSCode workspace config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
           node-version: 22
           cache: yarn
       - run: yarn install --immutable
+      - run: yarn format:check
+      - run: yarn lint
       - run: yarn astro check
       - run: yarn build
       - uses: actions/upload-pages-artifact@v3

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+dist/
+public/
+.astro/
+.yarn/
+*.min.js
+*.min.css

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,14 @@
+{
+  "semi": true,
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "plugins": ["prettier-plugin-astro"],
+  "overrides": [
+    {
+      "files": "*.astro",
+      "options": {
+        "parser": "astro"
+      }
+    }
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "arcanis.vscode-zipfs",
+    "astro-build.astro-vscode",
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "search.exclude": {
+    "**/.yarn": true
+  },
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "[astro]": {
+    "editor.defaultFormatter": "astro-build.astro-vscode"
+  },
+  "eslint.validate": ["javascript", "typescript", "astro"]
+}

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,6 @@
+# Yarn PnP and pnpm linkers break Prettier and ESLint plugin resolution for
+# .astro files. Prettier uses import-meta-resolve which bypasses PnP
+# (yarnpkg/berry#6167), and ESLint flat config has PnP SDK issues
+# (yarnpkg/berry#6219). The pnpm linker's strict isolation causes the same
+# failures for transitive deps like astro-eslint-parser.
+nodeLinker: node-modules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ Astro's markdown syntax highlighting is disabled (`markdown.syntaxHighlight: fal
 ## Content Conventions
 
 Blog post frontmatter (YAML `---` delimiters):
+
 - `author`, `date`, `title`, `description`, `type` (always "post")
 - `categories` — array of tags
 - `featured` — filename of featured image

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,11 +1,11 @@
-import { defineConfig } from 'astro/config';
-import sitemap from '@astrojs/sitemap';
+import { defineConfig } from "astro/config";
+import sitemap from "@astrojs/sitemap";
 
 export default defineConfig({
-  site: 'https://itsronald.com',
-  output: 'static',
+  site: "https://itsronald.com",
+  output: "static",
   build: {
-    format: 'directory',
+    format: "directory",
   },
   markdown: {
     syntaxHighlight: false,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,20 @@
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import astro from "eslint-plugin-astro";
+import prettier from "eslint-config-prettier";
+
+export default [
+  { ignores: ["dist/", "public/", ".astro/", ".yarn/"] },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  ...astro.configs.recommended,
+  {
+    files: ["**/*.astro"],
+    languageOptions: {
+      globals: {
+        astroHTML: "readonly",
+      },
+    },
+  },
+  prettier,
+];

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "@astrojs/check": "^0.9.6",
@@ -16,5 +20,14 @@
     "astro": "^5.17.1",
     "typescript": "^5.9.3"
   },
-  "packageManager": "yarn@4.12.0+sha512.f45ab632439a67f8bc759bf32ead036a1f413287b9042726b7cc4818b7b49e14e9423ba49b18f9e06ea4941c1ad062385b1d8760a8d5091a1a31e5f6219afca8"
+  "packageManager": "yarn@4.12.0+sha512.f45ab632439a67f8bc759bf32ead036a1f413287b9042726b7cc4818b7b49e14e9423ba49b18f9e06ea4941c1ad062385b1d8760a8d5091a1a31e5f6219afca8",
+  "devDependencies": {
+    "@eslint/js": "^10.0.1",
+    "eslint": "^10.0.1",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-astro": "^1.6.0",
+    "prettier": "^3.8.1",
+    "prettier-plugin-astro": "^0.14.1",
+    "typescript-eslint": "^8.56.0"
+  }
 }

--- a/src/components/Favicon.astro
+++ b/src/components/Favicon.astro
@@ -1,12 +1,12 @@
 ---
-import { siteConfig } from '../data/site';
+import { siteConfig } from "../data/site";
 
 const themeColor = siteConfig.faviconThemeColor;
 ---
 
-<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
-<link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
-<link rel="manifest" href="/manifest.json">
-<link rel="mask-icon" href="/safari-pinned-tab.svg" color={themeColor}>
-<meta name="theme-color" content={themeColor}>
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+<link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32" />
+<link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16" />
+<link rel="manifest" href="/manifest.json" />
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color={themeColor} />
+<meta name="theme-color" content={themeColor} />

--- a/src/components/FeaturedImage.astro
+++ b/src/components/FeaturedImage.astro
@@ -1,5 +1,5 @@
 ---
-import { getFeaturedImageUrl } from '../utils/featuredImage';
+import { getFeaturedImageUrl } from "../utils/featuredImage";
 
 interface Props {
   featured: string;
@@ -14,8 +14,10 @@ const { featured, featuredpath, featuredalt, date, permalink } = Astro.props;
 const imageUrl = getFeaturedImageUrl(featured, featuredpath, date);
 ---
 
-{imageUrl && (
-  <a href={permalink} class="image featured">
-    <img src={imageUrl} alt={featuredalt} />
-  </a>
-)}
+{
+  imageUrl && (
+    <a href={permalink} class="image featured">
+      <img src={imageUrl} alt={featuredalt} />
+    </a>
+  )
+}

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -1,7 +1,7 @@
 ---
-import { getCollection } from 'astro:content';
-import { siteConfig } from '../data/site';
-import { getPostUrl } from '../utils/postUrl';
+import { getCollection } from "astro:content";
+import { siteConfig } from "../data/site";
+import { getPostUrl } from "../utils/postUrl";
 
 interface Props {
   isHome?: boolean;
@@ -10,38 +10,56 @@ interface Props {
 
 const { isHome = false, showShareNav = false } = Astro.props;
 
-const posts = (await getCollection('blog'))
-  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+const posts = (await getCollection("blog")).sort(
+  (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
+);
 const recentPosts = posts.slice(0, siteConfig.postAmount.sidebar);
 const menuItems = [...siteConfig.menu].sort((a, b) => a.weight - b.weight);
 ---
 
 <!-- Header -->
 <header id="header">
-  {isHome ? (
-    <h1><a href="/">{siteConfig.navbarTitle}</a></h1>
-  ) : (
-    <h2><a href="/">{siteConfig.navbarTitle}</a></h2>
-  )}
+  {
+    isHome ? (
+      <h1>
+        <a href="/">{siteConfig.navbarTitle}</a>
+      </h1>
+    ) : (
+      <h2>
+        <a href="/">{siteConfig.navbarTitle}</a>
+      </h2>
+    )
+  }
 
   <nav class="links">
     <ul>
-      {menuItems.map(item => (
-        <li>
-          <a href={item.url}>
-            {item.icon && <Fragment><i class={item.icon}>&nbsp;</i></Fragment>}{item.name}
-          </a>
-        </li>
-      ))}
+      {
+        menuItems.map((item) => (
+          <li>
+            <a href={item.url}>
+              {item.icon && (
+                <Fragment>
+                  <i class={item.icon}>&nbsp;</i>
+                </Fragment>
+              )}
+              {item.name}
+            </a>
+          </li>
+        ))
+      }
     </ul>
   </nav>
   <nav class="main">
     <ul>
-      {showShareNav && (
-        <li id="share-nav" class="share-menu" style="display:none;">
-          <a class="fa-share-alt" href="#share-menu">Share</a>
-        </li>
-      )}
+      {
+        showShareNav && (
+          <li id="share-nav" class="share-menu" style="display:none;">
+            <a class="fa-share-alt" href="#share-menu">
+              Share
+            </a>
+          </li>
+        )
+      }
       <li class="search">
         <a class="fa-search" href="#search">Search</a>
         <form id="search" method="get" action="//google.com/search">
@@ -69,16 +87,22 @@ const menuItems = [...siteConfig.menu].sort((a, b) => a.weight - b.weight);
   <!-- Links -->
   <section>
     <ul class="links">
-      {menuItems.map(item => (
-        <li>
-          <a href={item.url}>
-            <h3>
-              {item.icon && <Fragment><i class={item.icon}>&nbsp;</i></Fragment>}
-              {item.name}
-            </h3>
-          </a>
-        </li>
-      ))}
+      {
+        menuItems.map((item) => (
+          <li>
+            <a href={item.url}>
+              <h3>
+                {item.icon && (
+                  <Fragment>
+                    <i class={item.icon}>&nbsp;</i>
+                  </Fragment>
+                )}
+                {item.name}
+              </h3>
+            </a>
+          </li>
+        ))
+      }
     </ul>
   </section>
 
@@ -88,11 +112,15 @@ const menuItems = [...siteConfig.menu].sort((a, b) => a.weight - b.weight);
       <header>
         <h3>Recent Posts</h3>
       </header>
-      {recentPosts.map(post => (
-        <li>
-          <a href={getPostUrl(post.slug)}><p>{post.data.title}</p></a>
-        </li>
-      ))}
+      {
+        recentPosts.map((post) => (
+          <li>
+            <a href={getPostUrl(post.slug)}>
+              <p>{post.data.title}</p>
+            </a>
+          </li>
+        ))
+      }
     </ul>
   </section>
 </section>

--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -14,15 +14,35 @@ const nextUrl = `${basePath}${currentPage + 1}/`;
 ---
 
 <ul class="actions pagination">
-  {hasPrev ? (
-    <li><a href={prevUrl} class="button big previous">Previous Page</a></li>
-  ) : (
-    <li><a href="#" class="disabled button big previous">Previous Page</a></li>
-  )}
+  {
+    hasPrev ? (
+      <li>
+        <a href={prevUrl} class="button big previous">
+          Previous Page
+        </a>
+      </li>
+    ) : (
+      <li>
+        <a href="#" class="disabled button big previous">
+          Previous Page
+        </a>
+      </li>
+    )
+  }
 
-  {hasNext ? (
-    <li><a href={nextUrl} class="button big next">Next Page</a></li>
-  ) : (
-    <li><a href="#" class="disabled button big next">Next Page</a></li>
-  )}
+  {
+    hasNext ? (
+      <li>
+        <a href={nextUrl} class="button big next">
+          Next Page
+        </a>
+      </li>
+    ) : (
+      <li>
+        <a href="#" class="disabled button big next">
+          Next Page
+        </a>
+      </li>
+    )
+  }
 </ul>

--- a/src/components/PostCategories.astro
+++ b/src/components/PostCategories.astro
@@ -7,13 +7,19 @@ const { categories } = Astro.props;
 ---
 
 <ul class="stats">
-  {categories.length > 0 && (
-    <li>
-      <i class="fa fa-map-signs">&nbsp;</i>
-      {categories.length > 1 ? 'Categories' : 'Category'}
-    </li>
-  )}
-  {categories.map(cat => (
-    <li><a href={`/categories/${cat.toLowerCase()}/`}>{cat}</a></li>
-  ))}
+  {
+    categories.length > 0 && (
+      <li>
+        <i class="fa fa-map-signs">&nbsp;</i>
+        {categories.length > 1 ? "Categories" : "Category"}
+      </li>
+    )
+  }
+  {
+    categories.map((cat) => (
+      <li>
+        <a href={`/categories/${cat.toLowerCase()}/`}>{cat}</a>
+      </li>
+    ))
+  }
 </ul>

--- a/src/components/PostContentList.astro
+++ b/src/components/PostContentList.astro
@@ -1,20 +1,29 @@
 ---
-import PostHeader from './PostHeader.astro';
-import FeaturedImage from './FeaturedImage.astro';
-import PostCategories from './PostCategories.astro';
-import { getReadingTime } from '../utils/readingTime';
-import { getPostUrl } from '../utils/postUrl';
-import type { CollectionEntry } from 'astro:content';
+import PostHeader from "./PostHeader.astro";
+import FeaturedImage from "./FeaturedImage.astro";
+import PostCategories from "./PostCategories.astro";
+import { getReadingTime } from "../utils/readingTime";
+import { getPostUrl } from "../utils/postUrl";
+import type { CollectionEntry } from "astro:content";
 
 interface Props {
-  post: CollectionEntry<'blog'>;
+  post: CollectionEntry<"blog">;
   Content: astroHTML.JSX.Element;
 }
 
 const { post, Content } = Astro.props;
-const { title, description, date, author, categories, featured, featuredpath, featuredalt } = post.data;
+const {
+  title,
+  description,
+  date,
+  author,
+  categories,
+  featured,
+  featuredpath,
+  featuredalt,
+} = post.data;
 const permalink = getPostUrl(post.slug);
-const readingTime = getReadingTime(post.body ?? '');
+const readingTime = getReadingTime(post.body ?? "");
 ---
 
 <article class="post">
@@ -27,15 +36,17 @@ const readingTime = getReadingTime(post.body ?? '');
     readingTime={readingTime}
   />
 
-  {featured && featuredpath && (
-    <FeaturedImage
-      featured={featured}
-      featuredpath={featuredpath}
-      featuredalt={featuredalt}
-      date={date}
-      permalink={permalink}
-    />
-  )}
+  {
+    featured && featuredpath && (
+      <FeaturedImage
+        featured={featured}
+        featuredpath={featuredpath}
+        featuredalt={featuredalt}
+        date={date}
+        permalink={permalink}
+      />
+    )
+  }
 
   <div class="post-summary">
     <Content />
@@ -56,7 +67,7 @@ const readingTime = getReadingTime(post.body ?? '');
     position: relative;
   }
   .post-summary::after {
-    content: '';
+    content: "";
     position: absolute;
     bottom: 0;
     left: 0;

--- a/src/components/PostContentSingle.astro
+++ b/src/components/PostContentSingle.astro
@@ -1,22 +1,31 @@
 ---
-import PostHeader from './PostHeader.astro';
-import FeaturedImage from './FeaturedImage.astro';
-import PostCategories from './PostCategories.astro';
-import ShareLinks from './ShareLinks.astro';
-import { getReadingTime } from '../utils/readingTime';
-import { getPostUrl } from '../utils/postUrl';
-import type { CollectionEntry } from 'astro:content';
+import PostHeader from "./PostHeader.astro";
+import FeaturedImage from "./FeaturedImage.astro";
+import PostCategories from "./PostCategories.astro";
+import ShareLinks from "./ShareLinks.astro";
+import { getReadingTime } from "../utils/readingTime";
+import { getPostUrl } from "../utils/postUrl";
+import type { CollectionEntry } from "astro:content";
 
 interface Props {
-  post: CollectionEntry<'blog'>;
+  post: CollectionEntry<"blog">;
   Content: astroHTML.JSX.Element;
   isH1?: boolean;
 }
 
 const { post, Content, isH1 = true } = Astro.props;
-const { title, description, date, author, categories, featured, featuredpath, featuredalt } = post.data;
+const {
+  title,
+  description,
+  date,
+  author,
+  categories,
+  featured,
+  featuredpath,
+  featuredalt,
+} = post.data;
 const permalink = getPostUrl(post.slug);
-const readingTime = getReadingTime(post.body ?? '');
+const readingTime = getReadingTime(post.body ?? "");
 ---
 
 <article class="post">
@@ -36,15 +45,17 @@ const readingTime = getReadingTime(post.body ?? '');
     </ul>
   </section>
 
-  {featured && featuredpath && (
-    <FeaturedImage
-      featured={featured}
-      featuredpath={featuredpath}
-      featuredalt={featuredalt}
-      date={date}
-      permalink={permalink}
-    />
-  )}
+  {
+    featured && featuredpath && (
+      <FeaturedImage
+        featured={featured}
+        featuredpath={featuredpath}
+        featuredalt={featuredalt}
+        date={date}
+        permalink={permalink}
+      />
+    )
+  }
 
   <div id="content">
     <Content />

--- a/src/components/PostHeader.astro
+++ b/src/components/PostHeader.astro
@@ -9,23 +9,37 @@ interface Props {
   isH1?: boolean;
 }
 
-const { title, permalink, description, date, author, readingTime, isH1 = false } = Astro.props;
+const {
+  title,
+  permalink,
+  description,
+  date,
+  author,
+  readingTime,
+  isH1 = false,
+} = Astro.props;
 
-const datetime = date.toISOString().split('T')[0];
-const displayDate = date.toLocaleDateString('en-US', {
-  year: 'numeric',
-  month: 'long',
-  day: 'numeric',
+const datetime = date.toISOString().split("T")[0];
+const displayDate = date.toLocaleDateString("en-US", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
 });
 ---
 
 <header>
   <div class="title">
-    {isH1 ? (
-      <h1><a href={permalink}>{title}</a></h1>
-    ) : (
-      <h2><a href={permalink}>{title}</a></h2>
-    )}
+    {
+      isH1 ? (
+        <h1>
+          <a href={permalink}>{title}</a>
+        </h1>
+      ) : (
+        <h2>
+          <a href={permalink}>{title}</a>
+        </h2>
+      )
+    }
     {description && <p>{description}</p>}
   </div>
   <div class="meta">

--- a/src/components/PrevNextNav.astro
+++ b/src/components/PrevNextNav.astro
@@ -1,33 +1,45 @@
 ---
-import type { CollectionEntry } from 'astro:content';
-import { getPostUrl } from '../utils/postUrl';
+import type { CollectionEntry } from "astro:content";
+import { getPostUrl } from "../utils/postUrl";
 
 interface Props {
-  prevPost: CollectionEntry<'blog'> | null;
-  nextPost: CollectionEntry<'blog'> | null;
+  prevPost: CollectionEntry<"blog"> | null;
+  nextPost: CollectionEntry<"blog"> | null;
 }
 
 const { prevPost, nextPost } = Astro.props;
 ---
 
 <ul class="actions pagination">
-  {prevPost ? (
-    <li>
-      <a href={getPostUrl(prevPost.slug)} class="button big previous">
-        {prevPost.data.title}
-      </a>
-    </li>
-  ) : (
-    <li><a href="#" class="disabled button big previous">Previous Post</a></li>
-  )}
+  {
+    prevPost ? (
+      <li>
+        <a href={getPostUrl(prevPost.slug)} class="button big previous">
+          {prevPost.data.title}
+        </a>
+      </li>
+    ) : (
+      <li>
+        <a href="#" class="disabled button big previous">
+          Previous Post
+        </a>
+      </li>
+    )
+  }
 
-  {nextPost ? (
-    <li>
-      <a href={getPostUrl(nextPost.slug)} class="button big next">
-        {nextPost.data.title}
-      </a>
-    </li>
-  ) : (
-    <li><a href="#" class="disabled button big next">Next Post</a></li>
-  )}
+  {
+    nextPost ? (
+      <li>
+        <a href={getPostUrl(nextPost.slug)} class="button big next">
+          {nextPost.data.title}
+        </a>
+      </li>
+    ) : (
+      <li>
+        <a href="#" class="disabled button big next">
+          Next Post
+        </a>
+      </li>
+    )
+  }
 </ul>

--- a/src/components/ShareLinks.astro
+++ b/src/components/ShareLinks.astro
@@ -1,5 +1,5 @@
 ---
-import { siteConfig } from '../data/site';
+import { siteConfig } from "../data/site";
 
 interface Props {
   permalink: string;
@@ -8,14 +8,18 @@ interface Props {
 }
 
 const { permalink, title, author } = Astro.props;
-const twitterHandle = 'itsronaldmartin';
+const twitterHandle = "itsronaldmartin";
 const absoluteUrl = encodeURIComponent(`${siteConfig.baseUrl}${permalink}`);
 const encodedTitle = encodeURIComponent(title);
 ---
 
 <!-- Twitter -->
 <li>
-  <a href={`//twitter.com/share?url=${absoluteUrl}&text=${encodedTitle}&via=${twitterHandle}`} target="_blank" class="share-btn twitter">
+  <a
+    href={`//twitter.com/share?url=${absoluteUrl}&text=${encodedTitle}&via=${twitterHandle}`}
+    target="_blank"
+    class="share-btn twitter"
+  >
     <i class="fa fa-twitter"></i>
     <p>Twitter</p>
   </a>
@@ -23,7 +27,11 @@ const encodedTitle = encodeURIComponent(title);
 
 <!-- Facebook -->
 <li>
-  <a href={`//www.facebook.com/sharer/sharer.php?u=${absoluteUrl}`} target="_blank" class="share-btn facebook">
+  <a
+    href={`//www.facebook.com/sharer/sharer.php?u=${absoluteUrl}`}
+    target="_blank"
+    class="share-btn facebook"
+  >
     <i class="fa fa-facebook"></i>
     <p>Facebook</p>
   </a>
@@ -31,7 +39,11 @@ const encodedTitle = encodeURIComponent(title);
 
 <!-- Reddit -->
 <li>
-  <a href={`//reddit.com/submit?url=${absoluteUrl}&title=${encodedTitle}`} target="_blank" class="share-btn reddit">
+  <a
+    href={`//reddit.com/submit?url=${absoluteUrl}&title=${encodedTitle}`}
+    target="_blank"
+    class="share-btn reddit"
+  >
     <i class="fa fa-reddit-alien"></i>
     <p>Reddit</p>
   </a>
@@ -39,7 +51,11 @@ const encodedTitle = encodeURIComponent(title);
 
 <!-- LinkedIn -->
 <li>
-  <a href={`//www.linkedin.com/shareArticle?url=${absoluteUrl}&title=${encodedTitle}`} target="_blank" class="share-btn linkedin">
+  <a
+    href={`//www.linkedin.com/shareArticle?url=${absoluteUrl}&title=${encodedTitle}`}
+    target="_blank"
+    class="share-btn linkedin"
+  >
     <i class="fa fa-linkedin"></i>
     <p>LinkedIn</p>
   </a>
@@ -47,7 +63,11 @@ const encodedTitle = encodeURIComponent(title);
 
 <!-- Email -->
 <li>
-  <a href={`mailto:?subject=${encodeURIComponent(`Check out this post by ${author}`)}&body=${absoluteUrl}`} target="_blank" class="share-btn email">
+  <a
+    href={`mailto:?subject=${encodeURIComponent(`Check out this post by ${author}`)}&body=${absoluteUrl}`}
+    target="_blank"
+    class="share-btn email"
+  >
     <i class="fa fa-envelope"></i>
     <p>Email</p>
   </a>

--- a/src/components/ShareMenu.astro
+++ b/src/components/ShareMenu.astro
@@ -1,5 +1,5 @@
 ---
-import ShareLinks from './ShareLinks.astro';
+import ShareLinks from "./ShareLinks.astro";
 
 interface Props {
   permalink: string;

--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -1,8 +1,8 @@
 ---
-import { getCollection } from 'astro:content';
-import { siteConfig } from '../data/site';
-import { getPostUrl } from '../utils/postUrl';
-import SocialIcons from './SocialIcons.astro';
+import { getCollection } from "astro:content";
+import { siteConfig } from "../data/site";
+import { getPostUrl } from "../utils/postUrl";
+import SocialIcons from "./SocialIcons.astro";
 
 interface Props {
   showCategories?: boolean;
@@ -10,8 +10,9 @@ interface Props {
 
 const { showCategories = true } = Astro.props;
 
-const allPosts = (await getCollection('blog'))
-  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+const allPosts = (await getCollection("blog")).sort(
+  (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
+);
 const recentPosts = allPosts.slice(0, siteConfig.postAmount.sidebar);
 
 // Compute category counts
@@ -21,18 +22,17 @@ for (const post of allPosts) {
     categoryMap.set(cat, (categoryMap.get(cat) || 0) + 1);
   }
 }
-const categories = [...categoryMap.entries()]
-  .sort((a, b) => b[1] - a[1]);
+const categories = [...categoryMap.entries()].sort((a, b) => b[1] - a[1]);
 
 const pic = siteConfig.intro.pic;
 
 function formatDate(date: Date): { datetime: string; display: string } {
   return {
-    datetime: date.toISOString().split('T')[0],
-    display: date.toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
+    datetime: date.toISOString().split("T")[0],
+    display: date.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
     }),
   };
 }
@@ -40,18 +40,25 @@ function formatDate(date: Date): { datetime: string; display: string } {
 
 <!-- Sidebar -->
 <section id="sidebar">
-
   <!-- Intro -->
   <section id="intro">
-    {pic.src && (
-      pic.circle ? (
-        <img src={pic.src} class="intro-circle" width={pic.width} alt={pic.alt} />
-      ) : pic.imperfect ? (
-        <a href="/" class="logo"><img src={pic.src} alt={pic.alt} /></a>
-      ) : (
-        <img src={pic.src} width={pic.width} alt={pic.alt} />
-      )
-    )}
+    {
+      pic.src &&
+        (pic.circle ? (
+          <img
+            src={pic.src}
+            class="intro-circle"
+            width={pic.width}
+            alt={pic.alt}
+          />
+        ) : pic.imperfect ? (
+          <a href="/" class="logo">
+            <img src={pic.src} alt={pic.alt} />
+          </a>
+        ) : (
+          <img src={pic.src} width={pic.width} alt={pic.alt} />
+        ))
+    }
     <header>
       <h2>{siteConfig.intro.header}</h2>
       <p set:html={siteConfig.intro.paragraph} />
@@ -67,60 +74,81 @@ function formatDate(date: Date): { datetime: string; display: string } {
       <header>
         <h3>Recent Posts</h3>
       </header>
-      {recentPosts.map(post => {
-        const { datetime, display } = formatDate(post.data.date);
-        return (
+      {
+        recentPosts.map((post) => {
+          const { datetime, display } = formatDate(post.data.date);
+          return (
+            <li>
+              <article>
+                <header>
+                  <h3>
+                    <a href={getPostUrl(post.slug)}>{post.data.title}</a>
+                  </h3>
+                  <time class="published" datetime={datetime}>
+                    {display}
+                  </time>
+                </header>
+              </article>
+            </li>
+          );
+        })
+      }
+      {
+        allPosts.length >= siteConfig.postAmount.sidebar && (
           <li>
-            <article>
-              <header>
-                <h3><a href={getPostUrl(post.slug)}>{post.data.title}</a></h3>
-                <time class="published" datetime={datetime}>{display}</time>
-              </header>
-            </article>
+            <ul class="actions">
+              <li>
+                <a href={siteConfig.viewMorePostLink} class="button">
+                  View more posts
+                </a>
+              </li>
+            </ul>
           </li>
-        );
-      })}
-      {allPosts.length >= siteConfig.postAmount.sidebar && (
-        <li>
-          <ul class="actions">
-            <li><a href={siteConfig.viewMorePostLink} class="button">View more posts</a></li>
-          </ul>
-        </li>
-      )}
+        )
+      }
     </ul>
   </section>
 
-  {showCategories && (
-    <!-- Categories List -->
-    <section id="categories">
-      <ul class="posts">
-        <header>
-          <h3><a href="/categories/">Categories</a></h3>
-        </header>
-        {categories.map(([name, count]) => (
-          <li>
-            <article>
-              <header>
-                <a href={`/categories/${name.toLowerCase()}/`}>{name}</a>
-                <span style="float:right;">{count}</span>
-              </header>
-            </article>
-          </li>
-        ))}
-      </ul>
-    </section>
-  )}
+  {
+    showCategories && (
+      <section id="categories">
+        <ul class="posts">
+          <header>
+            <h3>
+              <a href="/categories/">Categories</a>
+            </h3>
+          </header>
+          {categories.map(([name, count]) => (
+            <li>
+              <article>
+                <header>
+                  <a href={`/categories/${name.toLowerCase()}/`}>{name}</a>
+                  <span style="float:right;">{count}</span>
+                </header>
+              </article>
+            </li>
+          ))}
+        </ul>
+      </section>
+    )
+  }
 
   <!-- About -->
-  {siteConfig.intro.about && (
-    <section class="blurb">
-      <h2>About</h2>
-      <p>{siteConfig.intro.about}</p>
-      <ul class="actions">
-        <li><a href="/about/" class="button">Learn More</a></li>
-      </ul>
-    </section>
-  )}
+  {
+    siteConfig.intro.about && (
+      <section class="blurb">
+        <h2>About</h2>
+        <p>{siteConfig.intro.about}</p>
+        <ul class="actions">
+          <li>
+            <a href="/about/" class="button">
+              Learn More
+            </a>
+          </li>
+        </ul>
+      </section>
+    )
+  }
 
   <!-- Footer -->
   <section id="footer">
@@ -128,10 +156,12 @@ function formatDate(date: Date): { datetime: string; display: string } {
       <SocialIcons />
     </ul>
     <p class="copyright">
-      &copy; {siteConfig.title}. Design: <a href="http://html5up.net" target="_blank">HTML5 UP</a>.
-      Ported by <a href="//github.com/jpescador" target="_blank">Julio Pescador</a>.
-      Powered by <a href="//astro.build" target="_blank">Astro</a>
+      &copy; {siteConfig.title}. Design: <a
+        href="http://html5up.net"
+        target="_blank">HTML5 UP</a
+      >. Ported by <a href="//github.com/jpescador" target="_blank"
+        >Julio Pescador</a
+      >. Powered by <a href="//astro.build" target="_blank">Astro</a>
     </p>
   </section>
-
 </section>

--- a/src/components/SocialIcons.astro
+++ b/src/components/SocialIcons.astro
@@ -1,17 +1,30 @@
 ---
-import { siteConfig } from '../data/site';
+import { siteConfig } from "../data/site";
 ---
 
-{siteConfig.socialLinks.map(link => (
-  <li>
-    <a href={link.url} target="_blank" title={link.title} class={`fa ${link.icon}`}></a>
-  </li>
-))}
-{siteConfig.email && (
-  <li>
-    <a href={`mailto:${siteConfig.email}`} title="Email" class="fa fa-envelope"></a>
-  </li>
-)}
+{
+  siteConfig.socialLinks.map((link) => (
+    <li>
+      <a
+        href={link.url}
+        target="_blank"
+        title={link.title}
+        class={`fa ${link.icon}`}
+      />
+    </li>
+  ))
+}
+{
+  siteConfig.email && (
+    <li>
+      <a
+        href={`mailto:${siteConfig.email}`}
+        title="Email"
+        class="fa fa-envelope"
+      />
+    </li>
+  )
+}
 <li>
   <a href="/rss.xml" title="RSS" class="fa fa-rss"></a>
 </li>

--- a/src/content/blog/2016/05/first-post.md
+++ b/src/content/blog/2016/05/first-post.md
@@ -17,7 +17,6 @@ This site is being built with [Hugo](https://gohugo.io/), an awesome, Go-based s
 
 Since I work primarily on mobile platforms, what little I do know about web development has fallen off the wayside in the past couple of years. Hopefully, I can use this experience to catch up with the current state of affairs in webdev world. Using a static site generator perhaps isn't quite the same as building a site from scratch, but let's not reinvent the wheel, right?
 
-
 ## Makin' Blog Posts
 
 The syntax for creating a new post uses the following command:
@@ -28,13 +27,12 @@ hugo new relative/path/to/content.md
 
 For future reference, the docs are here: http://gohugo.io/content/types/.
 
-
 ## Wow, I've Learned Things Already?
 
 While this is my first post, I've already learned a few things that never came up while building apps:
 
 1. [What is TOML?](https://npf.io/2014/08/intro-to-toml/)
-2. [There are *so* many static site generators](https://www.staticgen.com/). I ended up choosing Hugo for a few reasons, the main one being that its written in Go (which I would like to learn eventually). It helps that the [documentation](http://gohugo.io/overview/introduction/) is quite thorough.
+2. [There are _so_ many static site generators](https://www.staticgen.com/). I ended up choosing Hugo for a few reasons, the main one being that its written in Go (which I would like to learn eventually). It helps that the [documentation](http://gohugo.io/overview/introduction/) is quite thorough.
 3. I had no idea that people actually visited my website. The screencap above from Google Analytics was for the Jekyll-based autogeneratred [GitHub Page](https://pages.github.com/) that this Hugo site is replacing. What's with those weird spikes last week? Maybe now that I've decided to add some content, more people will visit! Before deciding to revamp my website, I hadn't really worked with Google Analytics before. It was enormously easy to sign up, get a tracking ID, and enter it into GitHub Pages' site generator to come up with the data you see here. I highly recommend doing so!
 4. [Go HTML Templates are pretty easy to use.](http://gohugo.io/templates/go-templates/)
 5. **Managing a domain**: I've never had one before, so it was surprisingly easy to buy a couple (I used Namecheap) and point them at my GitHub page. Easy, free hosting with [great docs](https://help.github.com/articles/setting-up-your-pages-site-repository/). Thanks, GitHub.
@@ -42,7 +40,7 @@ While this is my first post, I've already learned a few things that never came u
 
 Even if I never write another blog post, this has already been an amazing learning experience. And, if I hadn't written this post, I probably wouldn't have noticed I'd learned this much!
 
-I really like learning though, so my tentative goal is to try to write something at least once a week, even if its just a check-in type of post. 
+I really like learning though, so my tentative goal is to try to write something at least once a week, even if its just a check-in type of post.
 
 ### Other Stuff I Want to Learn
 
@@ -53,10 +51,9 @@ I'm going to continue building out this site to learn some of the following:
 3. Go, the board game
 4. Disqus comment integration with Hugo
 
-
 ## Blog Content Ideas
 
-There are a lot of things I'd like to write about, and they aren't limited to programming topics. 
+There are a lot of things I'd like to write about, and they aren't limited to programming topics.
 
 - Android Studio 2.2 introduces recordable UI tests, fresh out of Google I/O just about a year after Apple introduced them in Xcode. How do they compare?
 - Touchable image maps in Android (in conjunction with [Dean](https://github.com/turniphead) and my [Star Wars: Rebellion app](https://github.com/turniphead/RebelBase))

--- a/src/content/blog/2016/06/lessons-learned-kotlin-dagger2.md
+++ b/src/content/blog/2016/06/lessons-learned-kotlin-dagger2.md
@@ -31,61 +31,57 @@ At the time of writing, I'm currently using Dagger v2.2 with Kotlin v1.0.2. I ha
 ### `kapt`, the Kotlin annotations processor
 
 Most of the tutorials on (Java) Dagger integrations rely on Hugo Visser's [Android Studio Annotations Processor](https://bitbucket.org/hvisser/android-apt). This is used with Dagger as follows:
-	
-	apply plugin: 'com.neenbedankt.android-apt'
-	 
-	buildscript {
-	    repositories {
-	        jcenter()
-	    }
-	    dependencies {
-	        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.4'
-	    }
-	}
-	 
-	android {
-	    ...
-	}
-	 
-	dependencies {
-	    apt "com.google.dagger:dagger-compiler:$rootProject.ext.daggerVersion"
+apply plugin: 'com.neenbedankt.android-apt'
+buildscript {
+repositories {
+jcenter()
+}
+dependencies {
+classpath 'com.neenbedankt.gradle.plugins:android-apt:1.4'
+}
+}
+android {
+...
+}
+dependencies {
+apt "com.google.dagger:dagger-compiler:$rootProject.ext.daggerVersion"
 	    compile "com.google.dagger:dagger:$rootProject.ext.daggerVersion"
-	    provided 'javax.annotation:jsr250-api:1.0' 
-	    
-	    ...
-	}
+provided 'javax.annotation:jsr250-api:1.0'
+
+...
+}
 
 However, when using these annotations in Kotlin files we should be using the built-in Kotlin annotation processor instead (source: [Stack Overflow](javax.annotation:javax.annotation-api)):
 
-	// apply plugin: 'com.neenbedankt.android-apt' - no longer necessary
-	 
-	buildscript {
-	    repositories {
-	        jcenter()
-	    }
-	    dependencies {
-	        // classpath 'com.neenbedankt.gradle.plugins:android-apt:1.4' - no longer necessary
-	    }
-	}
-	 
-	android {
-	    ...
-	}
+    // apply plugin: 'com.neenbedankt.android-apt' - no longer necessary
 
-	kapt {
-		generateStubs = true
-	}
-	 
-	dependencies {
-	    // apt "com.google.dagger:dagger-compiler:$rootProject.ext.daggerVersion" - use kapt instead
-	    kapt "com.google.dagger:dagger-compiler:$rootProject.ext.daggerVersion"
-	    compile "com.google.dagger:dagger:$rootProject.ext.daggerVersion"
-	    provided 'javax.annotation:jsr250-api:1.0' 
-	    
-	    ...
-	}
+    buildscript {
+        repositories {
+            jcenter()
+        }
+        dependencies {
+            // classpath 'com.neenbedankt.gradle.plugins:android-apt:1.4' - no longer necessary
+        }
+    }
 
-### Multiple JSR 250 Dependencies 
+    android {
+        ...
+    }
+
+    kapt {
+    	generateStubs = true
+    }
+
+    dependencies {
+        // apt "com.google.dagger:dagger-compiler:$rootProject.ext.daggerVersion" - use kapt instead
+        kapt "com.google.dagger:dagger-compiler:$rootProject.ext.daggerVersion"
+        compile "com.google.dagger:dagger:$rootProject.ext.daggerVersion"
+        provided 'javax.annotation:jsr250-api:1.0'
+
+        ...
+    }
+
+### Multiple JSR 250 Dependencies
 
 That `provided 'javax.annotation:jsr250-api:1.0'` line might have stuck out to you.
 
@@ -98,27 +94,32 @@ Developers haven't seemed to have agreed on a source for the [JSR-250 Java annot
 So, what gives? A rudimentary Google search suggests that all of these were implemented as part of Sun/Oracle's [GlassFish project](https://en.wikipedia.org/wiki/GlassFish). I didn't find what I was looking for in jCenter, so I found what I believe are the original uploads on good maven central. This is what I found:
 
 1. [`javax.annotation:javax.annotation-api:1.2`](http://search.maven.org/#artifactdetails%7Cjavax.annotation%7Cjavax.annotation-api%7C1.2%7Cjar)
-  * **Description:** "Common Annotations for the JavaTM Platform API"
-  * **URL (from metadata):** https://jcp.org/en/jsr/detail?id=250
-  * **Last updated:** 2013
-  * **Main `.jar` filesize:** 42311 bytes
-  * **Includes developer in metadata:** Rajiv Mordani, the JSR-250 lead at Sun (and now at Oracle).
+
+- **Description:** "Common Annotations for the JavaTM Platform API"
+- **URL (from metadata):** https://jcp.org/en/jsr/detail?id=250
+- **Last updated:** 2013
+- **Main `.jar` filesize:** 42311 bytes
+- **Includes developer in metadata:** Rajiv Mordani, the JSR-250 lead at Sun (and now at Oracle).
+
 2. [`org.glassfish:javax.annotation:10.0-b28`](http://search.maven.org/#artifactdetails%7Corg.glassfish%7Cjavax.annotation%7C10.0-b28%7Cjar)
-  * **Description:** "Common Annotations for the JavaTM Platform API version ${spec.version} Repackaged as OSGi bundle in GlassFish"
-  * **URL (from metadata):** None
-  * **Last updated:** 2011
-  * **Main `.jar` filesize:** 20542 bytes
-  * **Includes developer in metadata:** No
-  * **Notes:**
-     - Manifest includes in header: "Copyright 1997-2008 Sun Microsystems, Inc."
-     - Lists #3 below as an optional dependency!
-     - OSGi ([official site](https://www.osgi.org/developer/architecture/); [Wikipedia](https://en.wikipedia.org/wiki/OSGi)) is a standard for packaging Java components.
+
+- **Description:** "Common Annotations for the JavaTM Platform API version ${spec.version} Repackaged as OSGi bundle in GlassFish"
+- **URL (from metadata):** None
+- **Last updated:** 2011
+- **Main `.jar` filesize:** 20542 bytes
+- **Includes developer in metadata:** No
+- **Notes:**
+  - Manifest includes in header: "Copyright 1997-2008 Sun Microsystems, Inc."
+  - Lists #3 below as an optional dependency!
+  - OSGi ([official site](https://www.osgi.org/developer/architecture/); [Wikipedia](https://en.wikipedia.org/wiki/OSGi)) is a standard for packaging Java components.
+
 3. [`javax.annotation:jsr250-api:1.0`](http://search.maven.org/#artifactdetails%7Cjavax.annotation%7Cjsr250-api%7C1.0%7Cjar)
-  * **Description:** "JSR-250 Reference Implementation by Glassfish"
-  * **URL (from metadata):** https://jcp.org/aboutJava/communityprocess/final/jsr250/index.html
-  * **Last updated:** 2007
-  * **Main `.jar` filesize:** 5848 bytes
-  * **Includes developer in metadata:** No
+
+- **Description:** "JSR-250 Reference Implementation by Glassfish"
+- **URL (from metadata):** https://jcp.org/aboutJava/communityprocess/final/jsr250/index.html
+- **Last updated:** 2007
+- **Main `.jar` filesize:** 5848 bytes
+- **Includes developer in metadata:** No
 
 According to the [community page](https://jcp.org/en/jsr/detail?id=250) (which is the same URL provided by #1), the original release was in 2006, with maintenance releases in 2009 and 2013 (n.b.: [another maintenance release](https://jcp.org/aboutJava/communityprocess/maintenance/jsr250/JSR-250-MR3-changes.html) is scheduled for next month, Jul 2016!). So it looks like #1, `javax.annotation:javax.annotation-api:1.2` implements the latest version of this spec, whereas #3 implemented the first stable version almost ten years ago.
 
@@ -163,7 +164,7 @@ JetBrains' [Kotlin Android Extensions](https://kotlinlang.org/docs/tutorials/and
 
 **With kotlin-android-extensions:**
 
-	import kotlinx.android.synthetic.main.activity_main.* // Import all views in R.layout.activity_main
+    import kotlinx.android.synthetic.main.activity_main.* // Import all views in R.layout.activity_main
 
     class MyActivity: Activity() {
     	override fun onCreate(savedInstanceState: Bundle) {
@@ -177,9 +178,9 @@ JetBrains' [Kotlin Android Extensions](https://kotlinlang.org/docs/tutorials/and
 
 #### Dagger 2.2 Compatibility
 
-**Update 2016-10-05:** This seemed to be a problem with the Kotlin plugin rather than with Dagger itself. Code minify works fine with Kotlin v1.0.3 and the current version 1.0.4. 
+**Update 2016-10-05:** This seemed to be a problem with the Kotlin plugin rather than with Dagger itself. Code minify works fine with Kotlin v1.0.3 and the current version 1.0.4.
 
-Nice, right? _However_, I couldn't for the life of me make my view classes work with *both* Dagger and Kotlin. I started out with an Activity that used Dagger for injecting its presenter. Then, I tried factoring out those pesky `findViewById()` calls and using the synthetic properties directly, only to run into various build errors. Either the compiler couldn't import the synthetic layout "`Unresolved reference kotlinx`," or component classes generated by Dagger "`references unknown class X`," where X is the component interface that Dagger used to generate it. Okay.
+Nice, right? _However_, I couldn't for the life of me make my view classes work with _both_ Dagger and Kotlin. I started out with an Activity that used Dagger for injecting its presenter. Then, I tried factoring out those pesky `findViewById()` calls and using the synthetic properties directly, only to run into various build errors. Either the compiler couldn't import the synthetic layout "`Unresolved reference kotlinx`," or component classes generated by Dagger "`references unknown class X`," where X is the component interface that Dagger used to generate it. Okay.
 
 This was oft accompanied by the sad error message:
 
@@ -216,7 +217,7 @@ However, I think it's worth noting that these tips did _not_ fix the conflicts I
 
 **Update 2016-10-05:** In Kotlin plugin v1.0.3 and up, the automatic project setup works without modification.
 
-### `inject()` requires the *exact* class you're injecting into
+### `inject()` requires the _exact_ class you're injecting into
 
 Lastly, my "d'oh!" moment.
 
@@ -233,7 +234,7 @@ One of my Activities implemented an interface for interaction with its presenter
 
 `TimerPresenter.kt`:
 
-	class TimerPresenter
+    class TimerPresenter
     	@Inject constructor(override var view: TimerContract.TimerView)
     	: TimerContract.UserActionsListener {
     	...
@@ -243,15 +244,15 @@ I wanted to inject the presenter in `TimerActivity` using Dagger, so I implement
 
 `TimerComponent.kt`:
 
-	import dagger.Component
+    import dagger.Component
 
-	@Component(
-	        modules = arrayOf(TimerModule::class)
-	)
-	interface TimerComponent {
+    @Component(
+            modules = arrayOf(TimerModule::class)
+    )
+    interface TimerComponent {
 
-	    fun inject(timerView: TimerContract.TimerView)
-	}
+        fun inject(timerView: TimerContract.TimerView)
+    }
 
 `TimerActivity.kt`:
 
@@ -277,27 +278,26 @@ Despite `inject()` type checking for a `TimerActivity` that conforms to the `Tim
 
 `TimerComponent.kt`:
 
-	import dagger.Component
+    import dagger.Component
 
-	@Component(
-	        modules = arrayOf(TimerModule::class)
-	)
-	interface TimerComponent {
+    @Component(
+            modules = arrayOf(TimerModule::class)
+    )
+    interface TimerComponent {
 
-	//  fun inject(timerView: TimerContract.TimerView) Nope!
-	    fun inject(timerActivity: TimerActivity)	// Yup!
-	}
+    //  fun inject(timerView: TimerContract.TimerView) Nope!
+        fun inject(timerActivity: TimerActivity)	// Yup!
+    }
 
 Total noob move, I'm sure, but hey, now I know.
-
 
 ## Helpful Resources
 
 I probably wouldn't have figured out how to make everything work without the help of the following resources -- props to the makers:
 
-* damianpetla's [kotlin-dagger-example](https://github.com/damianpetla/kotlin-dagger-example)
-* Google's example [MVP+Dagger architected ToDo App](https://github.com/googlesamples/android-architecture/tree/todo-mvp-dagger)
-* soflete's [Android with Dagger](http://soflete.github.io/2016/04/01/Android-MVP-with-Dagger/) example
+- damianpetla's [kotlin-dagger-example](https://github.com/damianpetla/kotlin-dagger-example)
+- Google's example [MVP+Dagger architected ToDo App](https://github.com/googlesamples/android-architecture/tree/todo-mvp-dagger)
+- soflete's [Android with Dagger](http://soflete.github.io/2016/04/01/Android-MVP-with-Dagger/) example
 
 **Update 2016-10-05:** I now have my own working Kotlin/Dagger app [on GitHub](https://github.com/ronaldsmartin/20twenty20).
 

--- a/src/content/blog/2016/10/my-first-library.md
+++ b/src/content/blog/2016/10/my-first-library.md
@@ -45,7 +45,7 @@ Perhaps you'll agree with me that from our high-level human standpoint, it appea
 2. The white current page dot slides along the path to its new location.
 3. The path that was created shrinks back under the white current page dot.
 
-Is that all we need to do to replicate this effect? How can we break this down in more detail? 
+Is that all we need to do to replicate this effect? How can we break this down in more detail?
 
 ### Tool #2: .GIF frame splitting
 

--- a/src/content/blog/2017/06/simple-ordinal-date-queries.md
+++ b/src/content/blog/2017/06/simple-ordinal-date-queries.md
@@ -15,7 +15,7 @@ I had a very specific question a while ago:
 
 > When is the next 5th Sunday of the month?
 
-That is, what is the next date which is not only a Sunday, but also the 5th occurrance of Sunday in its enclosing month? 
+That is, what is the next date which is not only a Sunday, but also the 5th occurrance of Sunday in its enclosing month?
 
 This only occurs a handful of times in any given year (in the Gregorian calendar): an average of 30 days per month means `30 days/month / 7 days/week = ~4.29 weeks/month`. For there, since each weekday occurs exactly once per week, this then implies that most weekdays will occur _4.29_ times on average per month as well. That little fractional part adds up though, so periodically the calendar will line up such that the "Fifth Sunday" does occur.
 
@@ -26,9 +26,11 @@ I have a recurring appointment on 5th Sundays of the month, but at the time I st
 I sketched out a rough, brute force plan in my head. Loop through months in a calendar, maybe then loop through each Sunday, returning the date if the Sunday was a fifth occurrence. Not the worst thing in the world. But then I looked at the Foundation `Date` API to refine the idea and stumbled upon the obscure [`weekdayOrdinal` property on `NSDateComponents`](https://developer.apple.com/documentation/foundation/nsdatecomponents/1409476-weekdayordinal):
 
 > #### Declaration
+>
 > `var weekdayOrdinal: Int { get set }`
 >
 > #### Discussion
+>
 > Weekday ordinal units represent the position of the weekday within the next larger calendar unit, such as the month. For example, 2 is the weekday ordinal unit for the second Friday of the month.
 
 💡💡💡 "Oh, that's exactly what I need!"
@@ -57,10 +59,10 @@ And that's it! Thanks, Foundation engineers!
 
 Knowing the next date is useful and answered my original question, but isn't quite enough for all use cases. If you need to query the calendar for multiple dates, iOS 8 also introduced the `NSCalendar` function [`enumerateDates(startingAfter:matching:options:using:)`](https://developer.apple.com/documentation/foundation/nscalendar/1413938-enumeratedates) that calls a closure you provide with each successive query result (synchronously!). The function params are as follows:
 
-* `startingAfter start: Date` - as described by the label, the date at which to start querying the calendar
-* `matching components: DateComponents` - the constraints on the query, e.g. for us, '5th Sundays'
-* `matchingPolicy: Calendar.MatchingPolicy` - the strategy to use when encountering ambiguous matches, e.g. due to Daylight Saving Time. Possible values can be [found here](https://developer.apple.com/documentation/foundation/calendar.matchingpolicy).
-* `using block: (Date?, Bool, inout Bool) -> Void` - the closure that will be called with each matching query result. It takes three params: the first is the matching date, the second is a `Bool` describing whether this is an exact match to your `components` (whether or not this is relevant depends on your `matchingPolicy`), and finally, another `Bool` flag you can use to stop searching for more dates.
+- `startingAfter start: Date` - as described by the label, the date at which to start querying the calendar
+- `matching components: DateComponents` - the constraints on the query, e.g. for us, '5th Sundays'
+- `matchingPolicy: Calendar.MatchingPolicy` - the strategy to use when encountering ambiguous matches, e.g. due to Daylight Saving Time. Possible values can be [found here](https://developer.apple.com/documentation/foundation/calendar.matchingpolicy).
+- `using block: (Date?, Bool, inout Bool) -> Void` - the closure that will be called with each matching query result. It takes three params: the first is the matching date, the second is a `Bool` describing whether this is an exact match to your `components` (whether or not this is relevant depends on your `matchingPolicy`), and finally, another `Bool` flag you can use to stop searching for more dates.
 
 You use it like this:
 
@@ -68,7 +70,7 @@ You use it like this:
 // Find all the fifth Sundays up through the end of next year (2018).
 calendar.enumerateDates(startingAfter: now,
                         matching: components,
-                        matchingPolicy: .strict) { 
+                        matchingPolicy: .strict) {
     date, isExactMatch, shouldStop in
     // I'm only interested in continuing with exact date matches
     guard let date = date, isExactMatch else { return }

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,17 +1,17 @@
-import { defineCollection, z } from 'astro:content';
+import { defineCollection, z } from "astro:content";
 
 const blogCollection = defineCollection({
-  type: 'content',
+  type: "content",
   schema: z.object({
     title: z.string(),
-    author: z.string().default('Ronald Martin'),
+    author: z.string().default("Ronald Martin"),
     date: z.coerce.date(),
-    description: z.string().default(''),
+    description: z.string().default(""),
     categories: z.array(z.string()).default([]),
-    featured: z.string().default(''),
-    featuredalt: z.string().default(''),
-    featuredpath: z.string().default(''),
-    type: z.string().default('post'),
+    featured: z.string().default(""),
+    featuredalt: z.string().default(""),
+    featuredpath: z.string().default(""),
+    type: z.string().default("post"),
   }),
 });
 

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -12,17 +12,58 @@ export interface MenuItem {
   weight: number;
 }
 
-function buildSocialLinks(social: Record<string, string | undefined>): SocialLink[] {
-  const urlPatterns: Record<string, { url: (u: string) => string; title: string; icon: string }> = {
-    github:         { url: u => `//github.com/${u}`,               title: 'GitHub',         icon: 'fa-github' },
-    bitbucket:      { url: u => `//bitbucket.com/${u}`,            title: 'Bitbucket',      icon: 'fa-bitbucket' },
-    instagram:      { url: u => `//instagram.com/${u}`,            title: 'Instagram',      icon: 'fa-instagram' },
-    youtube:        { url: u => `//youtube.com/${u}`,              title: 'YouTube',        icon: 'fa-youtube' },
-    medium:         { url: u => `//medium.com/@${u}`,              title: 'Medium',         icon: 'fa-medium' },
-    linkedin:       { url: u => `//linkedin.com/in/${u}`,          title: 'LinkedIn',       icon: 'fa-linkedin' },
-    stackoverflow:  { url: u => `//stackoverflow.com/users/${u}`,  title: 'Stack Overflow', icon: 'fa-stack-overflow' },
-    facebook:       { url: u => `//facebook.com/${u}`,             title: 'Facebook',       icon: 'fa-facebook' },
-    twitter:        { url: u => `//twitter.com/${u}`,              title: 'Twitter',        icon: 'fa-twitter' },
+function buildSocialLinks(
+  social: Record<string, string | undefined>,
+): SocialLink[] {
+  const urlPatterns: Record<
+    string,
+    { url: (u: string) => string; title: string; icon: string }
+  > = {
+    github: {
+      url: (u) => `//github.com/${u}`,
+      title: "GitHub",
+      icon: "fa-github",
+    },
+    bitbucket: {
+      url: (u) => `//bitbucket.com/${u}`,
+      title: "Bitbucket",
+      icon: "fa-bitbucket",
+    },
+    instagram: {
+      url: (u) => `//instagram.com/${u}`,
+      title: "Instagram",
+      icon: "fa-instagram",
+    },
+    youtube: {
+      url: (u) => `//youtube.com/${u}`,
+      title: "YouTube",
+      icon: "fa-youtube",
+    },
+    medium: {
+      url: (u) => `//medium.com/@${u}`,
+      title: "Medium",
+      icon: "fa-medium",
+    },
+    linkedin: {
+      url: (u) => `//linkedin.com/in/${u}`,
+      title: "LinkedIn",
+      icon: "fa-linkedin",
+    },
+    stackoverflow: {
+      url: (u) => `//stackoverflow.com/users/${u}`,
+      title: "Stack Overflow",
+      icon: "fa-stack-overflow",
+    },
+    facebook: {
+      url: (u) => `//facebook.com/${u}`,
+      title: "Facebook",
+      icon: "fa-facebook",
+    },
+    twitter: {
+      url: (u) => `//twitter.com/${u}`,
+      title: "Twitter",
+      icon: "fa-twitter",
+    },
   };
 
   const links: SocialLink[] = [];
@@ -70,10 +111,15 @@ export const siteConfig = {
   postAmount: { sidebar: 2 },
 
   menu: [
-    { name: "Blog",       url: "/blog",       icon: "fa fa-newspaper-o", weight: 1 },
-    { name: "Categories", url: "/categories",  icon: "fa fa-map-signs",   weight: 2 },
-    { name: "About",      url: "/about",       icon: "fa fa-info-circle", weight: 3 },
-    { name: "Projects",   url: "/projects",    icon: "fa fa-code",        weight: 4 },
+    { name: "Blog", url: "/blog", icon: "fa fa-newspaper-o", weight: 1 },
+    {
+      name: "Categories",
+      url: "/categories",
+      icon: "fa fa-map-signs",
+      weight: 2,
+    },
+    { name: "About", url: "/about", icon: "fa fa-info-circle", weight: 3 },
+    { name: "Projects", url: "/projects", icon: "fa fa-code", weight: 4 },
   ] satisfies MenuItem[],
 
   socialLinks: buildSocialLinks({

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,6 @@
 ---
-import Favicon from '../components/Favicon.astro';
-import { siteConfig } from '../data/site';
+import Favicon from "../components/Favicon.astro";
+import { siteConfig } from "../data/site";
 
 interface Props {
   title?: string;
@@ -10,13 +10,11 @@ interface Props {
 
 const { title, description, author } = Astro.props;
 
-const pageTitle = title
-  ? `${title} - ${siteConfig.title}`
-  : siteConfig.title;
+const pageTitle = title ? `${title} - ${siteConfig.title}` : siteConfig.title;
 const pageDescription = description || siteConfig.description;
 ---
 
-<!DOCTYPE HTML>
+<!doctype html>
 <html>
   <head>
     <title>{pageTitle}</title>
@@ -43,6 +41,8 @@ const pageDescription = description || siteConfig.description;
     </div>
     <a id="back-to-top" href="#" class="fa fa-arrow-up fa-border fa-2x"></a>
     <script src="/js/main.min.js" is:inline></script>
-    <script is:inline>hljs.initHighlightingOnLoad();</script>
+    <script is:inline>
+      hljs.initHighlightingOnLoad();
+    </script>
   </body>
 </html>

--- a/src/layouts/PageWithSidebar.astro
+++ b/src/layouts/PageWithSidebar.astro
@@ -1,7 +1,7 @@
 ---
-import BaseLayout from './BaseLayout.astro';
-import Navbar from '../components/Navbar.astro';
-import Sidebar from '../components/Sidebar.astro';
+import BaseLayout from "./BaseLayout.astro";
+import Navbar from "../components/Navbar.astro";
+import Sidebar from "../components/Sidebar.astro";
 
 interface Props {
   title?: string;

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -1,16 +1,16 @@
 ---
-import PageWithSidebar from './PageWithSidebar.astro';
-import PostContentSingle from '../components/PostContentSingle.astro';
-import PrevNextNav from '../components/PrevNextNav.astro';
-import ShareMenu from '../components/ShareMenu.astro';
-import { getPostUrl } from '../utils/postUrl';
-import type { CollectionEntry } from 'astro:content';
+import PageWithSidebar from "./PageWithSidebar.astro";
+import PostContentSingle from "../components/PostContentSingle.astro";
+import PrevNextNav from "../components/PrevNextNav.astro";
+import ShareMenu from "../components/ShareMenu.astro";
+import { getPostUrl } from "../utils/postUrl";
+import type { CollectionEntry } from "astro:content";
 
 interface Props {
-  post: CollectionEntry<'blog'>;
+  post: CollectionEntry<"blog">;
   Content: astroHTML.JSX.Element;
-  prevPost: CollectionEntry<'blog'> | null;
-  nextPost: CollectionEntry<'blog'> | null;
+  prevPost: CollectionEntry<"blog"> | null;
+  nextPost: CollectionEntry<"blog"> | null;
 }
 
 const { post, Content, prevPost, nextPost } = Astro.props;

--- a/src/layouts/SinglePage.astro
+++ b/src/layouts/SinglePage.astro
@@ -1,5 +1,5 @@
 ---
-import PageWithSidebar from './PageWithSidebar.astro';
+import PageWithSidebar from "./PageWithSidebar.astro";
 
 const { frontmatter } = Astro.props;
 const title = frontmatter?.title;

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,5 +1,5 @@
 ---
-import PageWithSidebar from '../layouts/PageWithSidebar.astro';
+import PageWithSidebar from "../layouts/PageWithSidebar.astro";
 ---
 
 <PageWithSidebar title="Page Not Found">

--- a/src/pages/about.md
+++ b/src/pages/about.md
@@ -14,19 +14,23 @@ I really enjoy building stuff, particularly mobile apps. I also occasionally bui
 My non-technical interests include (but are certainly not limited to):
 
 ### Music
+
 Discovering and enjoying new music is one of my passions. My recent playlist has contained mostly electronic funk and R&B, but I really believe in music as art and strive to appreciate all genres.
 
 I'd really like to make my own music and will write about how that goes eventually. I just bought a tambourine and am pretty pumped about it, but usually strum on my ukulele and sing a lot.
 
 ### Casual Math
+
 Have you heard of the [Birthday Problem](https://en.wikipedia.org/wiki/Birthday_problem)? Well, it turns out that once you get 23 people in a room, you have about a 50% chance of two people inside sharing the same birthday!
 
 I don't engage with higher level math as much as I used to, but I still take a special joy in learning about results and problems like this illustrate our world just a bit better.
 
 ### Delicious Foods!
+
 I love trying new foods. I wouldn't go so far as to say I'm a foodie; I am an equal opportunity nom-er. If you ask me to try a new restaurant with you, I will probably say yes.
 
 ### Philosophy
+
 Sometimes you need nourishment for your mind too, right? Here's one of my favorites to discuss, courtesy of my friend Joe:
 
 > If you had to choose between being able to eat whatever you want with no negative consequences or never having to eat again, which would you pick?
@@ -34,15 +38,19 @@ Sometimes you need nourishment for your mind too, right? Here's one of my favori
 I enjoy eating as much as the next guy, but I'd actually go with the second one for reasons I'd be happy to discuss with you. I'd also love to hear what you think!
 
 ### Volleyball
+
 I've played volleyball since high school and try to keep up as time permits by going to open gyms and working as a volunteer coach for a local youth team.
 
 ### Basketball
+
 I don't really play any more, but I grew up in the Bay and support the Golden State Warriors. Go Dubs!
 
 ### Reading
+
 I read a lot and love to do it. I am a bit of a news junkie, but tend toward adventure stories in my spare time.
 
 ### Gaming
+
 I like board games and video games and especially enjoy playing co-op games with other people.
 When I play on my own, I usually go for action RPGs (_Dragon Age_, _Legend of Zelda_) or puzzle games (_Ace Attorney_, _Pushmo_).
 

--- a/src/pages/blog/[page].astro
+++ b/src/pages/blog/[page].astro
@@ -1,14 +1,14 @@
 ---
-import PageWithSidebar from '../../layouts/PageWithSidebar.astro';
-import PostContentList from '../../components/PostContentList.astro';
-import Pagination from '../../components/Pagination.astro';
-import { getCollection } from 'astro:content';
-import { siteConfig } from '../../data/site';
-import type { GetStaticPaths, InferGetStaticPropsType } from 'astro';
+import PageWithSidebar from "../../layouts/PageWithSidebar.astro";
+import PostContentList from "../../components/PostContentList.astro";
+import Pagination from "../../components/Pagination.astro";
+import { getCollection } from "astro:content";
+import { siteConfig } from "../../data/site";
+import type { GetStaticPaths, InferGetStaticPropsType } from "astro";
 
 export const getStaticPaths = (async () => {
-  const posts = (await getCollection('blog')).sort(
-    (a, b) => b.data.date.valueOf() - a.data.date.valueOf()
+  const posts = (await getCollection("blog")).sort(
+    (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
   );
 
   const pageSize = siteConfig.paginate;
@@ -32,13 +32,19 @@ const rendered = await Promise.all(
   pagePosts.map(async (post) => {
     const { Content } = await post.render();
     return { post, Content };
-  })
+  }),
 );
 ---
 
 <PageWithSidebar title={`Blog - Page ${currentPage}`}>
-  {rendered.map(({ post, Content }) => (
-    <PostContentList post={post} Content={Content} />
-  ))}
-  <Pagination currentPage={currentPage} totalPages={totalPages} basePath="/blog/" />
+  {
+    rendered.map(({ post, Content }) => (
+      <PostContentList post={post} Content={Content} />
+    ))
+  }
+  <Pagination
+    currentPage={currentPage}
+    totalPages={totalPages}
+    basePath="/blog/"
+  />
 </PageWithSidebar>

--- a/src/pages/blog/[year]/[month]/[slug].astro
+++ b/src/pages/blog/[year]/[month]/[slug].astro
@@ -1,18 +1,18 @@
 ---
-import PostLayout from '../../../../layouts/PostLayout.astro';
-import { getCollection } from 'astro:content';
-import type { GetStaticPaths, InferGetStaticPropsType } from 'astro';
+import PostLayout from "../../../../layouts/PostLayout.astro";
+import { getCollection } from "astro:content";
+import type { GetStaticPaths, InferGetStaticPropsType } from "astro";
 
 export const getStaticPaths = (async () => {
-  const posts = (await getCollection('blog')).sort(
-    (a, b) => b.data.date.valueOf() - a.data.date.valueOf()
+  const posts = (await getCollection("blog")).sort(
+    (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
   );
 
   return posts.map((post, index) => {
     // slug format: "2016/06/my-post" → year="2016", month="06", slug="my-post"
-    const parts = post.slug.split('/');
+    const parts = post.slug.split("/");
     const [year, month, ...rest] = parts;
-    const slugPart = rest.join('/');
+    const slugPart = rest.join("/");
 
     // Chronological navigation: newer = prev (above in sorted list), older = next
     const prevPost = index > 0 ? posts[index - 1] : null;
@@ -30,4 +30,9 @@ const { post, prevPost, nextPost } = Astro.props as Props;
 const { Content } = await post.render();
 ---
 
-<PostLayout post={post} Content={Content} prevPost={prevPost} nextPost={nextPost} />
+<PostLayout
+  post={post}
+  Content={Content}
+  prevPost={prevPost}
+  nextPost={nextPost}
+/>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,12 +1,12 @@
 ---
-import PageWithSidebar from '../../layouts/PageWithSidebar.astro';
-import PostContentList from '../../components/PostContentList.astro';
-import Pagination from '../../components/Pagination.astro';
-import { getCollection } from 'astro:content';
-import { siteConfig } from '../../data/site';
+import PageWithSidebar from "../../layouts/PageWithSidebar.astro";
+import PostContentList from "../../components/PostContentList.astro";
+import Pagination from "../../components/Pagination.astro";
+import { getCollection } from "astro:content";
+import { siteConfig } from "../../data/site";
 
-const posts = (await getCollection('blog')).sort(
-  (a, b) => b.data.date.valueOf() - a.data.date.valueOf()
+const posts = (await getCollection("blog")).sort(
+  (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
 );
 
 const pageSize = siteConfig.paginate;
@@ -17,13 +17,15 @@ const rendered = await Promise.all(
   pagePosts.map(async (post) => {
     const { Content } = await post.render();
     return { post, Content };
-  })
+  }),
 );
 ---
 
 <PageWithSidebar title="Blog">
-  {rendered.map(({ post, Content }) => (
-    <PostContentList post={post} Content={Content} />
-  ))}
+  {
+    rendered.map(({ post, Content }) => (
+      <PostContentList post={post} Content={Content} />
+    ))
+  }
   <Pagination currentPage={1} totalPages={totalPages} basePath="/blog/" />
 </PageWithSidebar>

--- a/src/pages/categories/[category].astro
+++ b/src/pages/categories/[category].astro
@@ -1,12 +1,12 @@
 ---
-import PageWithSidebar from '../../layouts/PageWithSidebar.astro';
-import PostContentList from '../../components/PostContentList.astro';
-import { getCollection } from 'astro:content';
-import type { GetStaticPaths, InferGetStaticPropsType } from 'astro';
+import PageWithSidebar from "../../layouts/PageWithSidebar.astro";
+import PostContentList from "../../components/PostContentList.astro";
+import { getCollection } from "astro:content";
+import type { GetStaticPaths, InferGetStaticPropsType } from "astro";
 
 export const getStaticPaths = (async () => {
-  const posts = (await getCollection('blog')).sort(
-    (a, b) => b.data.date.valueOf() - a.data.date.valueOf()
+  const posts = (await getCollection("blog")).sort(
+    (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
   );
 
   // Collect all unique categories
@@ -22,7 +22,7 @@ export const getStaticPaths = (async () => {
     props: {
       category: cat,
       posts: posts.filter((p) =>
-        p.data.categories.some((c) => c.toLowerCase() === cat.toLowerCase())
+        p.data.categories.some((c) => c.toLowerCase() === cat.toLowerCase()),
       ),
     },
   }));
@@ -35,7 +35,7 @@ const rendered = await Promise.all(
   posts.map(async (post) => {
     const { Content } = await post.render();
     return { post, Content };
-  })
+  }),
 );
 ---
 
@@ -45,7 +45,9 @@ const rendered = await Promise.all(
       <h2>{category}</h2>
     </div>
   </header>
-  {rendered.map(({ post, Content }) => (
-    <PostContentList post={post} Content={Content} />
-  ))}
+  {
+    rendered.map(({ post, Content }) => (
+      <PostContentList post={post} Content={Content} />
+    ))
+  }
 </PageWithSidebar>

--- a/src/pages/categories/index.astro
+++ b/src/pages/categories/index.astro
@@ -1,8 +1,8 @@
 ---
-import PageWithSidebar from '../../layouts/PageWithSidebar.astro';
-import { getCollection } from 'astro:content';
+import PageWithSidebar from "../../layouts/PageWithSidebar.astro";
+import { getCollection } from "astro:content";
 
-const posts = await getCollection('blog');
+const posts = await getCollection("blog");
 
 // Build category → count map
 const categoryMap = new Map<string, number>();
@@ -27,11 +27,15 @@ const categories = [...categoryMap.entries()].sort((a, b) => {
       </div>
     </header>
     <ul class="actions">
-      {categories.map(([name, count]) => (
-        <li>
-          <a href={`/categories/${name.toLowerCase()}/`}>{name} ({count})</a>
-        </li>
-      ))}
+      {
+        categories.map(([name, count]) => (
+          <li>
+            <a href={`/categories/${name.toLowerCase()}/`}>
+              {name} ({count})
+            </a>
+          </li>
+        ))
+      }
     </ul>
   </article>
 </PageWithSidebar>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,12 +1,12 @@
 ---
-import PageWithSidebar from '../layouts/PageWithSidebar.astro';
-import PostContentSingle from '../components/PostContentSingle.astro';
-import ShareMenu from '../components/ShareMenu.astro';
-import { getCollection } from 'astro:content';
-import { getPostUrl } from '../utils/postUrl';
+import PageWithSidebar from "../layouts/PageWithSidebar.astro";
+import PostContentSingle from "../components/PostContentSingle.astro";
+import ShareMenu from "../components/ShareMenu.astro";
+import { getCollection } from "astro:content";
+import { getPostUrl } from "../utils/postUrl";
 
-const posts = (await getCollection('blog')).sort(
-  (a, b) => b.data.date.valueOf() - a.data.date.valueOf()
+const posts = (await getCollection("blog")).sort(
+  (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
 );
 const latestPost = posts[0];
 const { Content } = await latestPost.render();

--- a/src/pages/projects.md
+++ b/src/pages/projects.md
@@ -8,84 +8,97 @@ author: "Ronald Martin"
 
 ### [Material ViewPagerIndicator](https://github.com/ronaldsmartin/Material-ViewPagerIndicator)
 
-* _On Github:_ https://github.com/ronaldsmartin/Material-ViewPagerIndicator
+- _On Github:_ https://github.com/ronaldsmartin/Material-ViewPagerIndicator
 
 An Android library that implements pretty Material Design animations for swipeable pages. I'm trying to write a few posts on what I've learned from building it: here's [Part I](/blog/2016/10/my-first-library).
 
 ### [20 twenty 20](/20twenty20)
 
-* _On Github:_ https://github.com/ronaldsmartin/20twenty20
+- _On Github:_ https://github.com/ronaldsmartin/20twenty20
 
 An Android app built with Dagger 2 and RxJava (written fully in Kotlin!). Addresses the (unfortunately common) unhealthy habit of getting stuck sitting and staring in front of the computer too long by notifying you to do exercises and take eye breaks [per the 20-20-20 Rule](/20twenty20).
 
-I tinker with this on and off, and it already works rather well. In the future, I'd like to build in automatic scheduler to turn it on daily or something. (So I can be *really* lazy about my healthy habits...?)
+I tinker with this on and off, and it already works rather well. In the future, I'd like to build in automatic scheduler to turn it on daily or something. (So I can be _really_ lazy about my healthy habits...?)
 
 [<img src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png" width="250" alt="Get it on Google Play">](https://play.google.com/store/apps/details?id=com.itsronald.twenty2020&utm_source=global_co&utm_medium=prtnr&utm_content=Mar2515&utm_campaign=PartBadge&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1)
 
-###  "And now, Your Highness, we will discuss the location of your hidden Rebel base."
+### "And now, Your Highness, we will discuss the location of your hidden Rebel base."
+
 [My roomie Dean](https://deanwilhelmi.wordpress.com/) and I threw together a Android app (Kotlin-based) to augment our galactic battles in the [Star Wars: Rebellion](https://www.fantasyflightgames.com/en/products/star-wars-rebellion/) board game. So far, it implements a basic visual state toggle (pretty much a color-coded grid) so that the Imperial players can keep track of their intelligence on each system. I started this off as a RecyclerView-based grid just to get the project off the ground, but once we can get some quality images of the game board we're going to learn how to make arbitrarily-shaped clickable regions to turn this into a touchable mini-map.
 
 **Update:** I am updating the [AndroidImageMap library](https://github.com/ronaldsmartin/AndroidImageMap) to serve this purpose.
 
 Long term, we're thinking about adding a game clock that syncs across all players' devices because our matches take too long. Longer term, we'd love to build an AI that'll play the game against us.
 
-* Repo on on GitHub: https://github.com/turniphead/RebelBase
+- Repo on on GitHub: https://github.com/turniphead/RebelBase
 
 ### You Are Here!
+
 I'm learning my way around the awesome [Hugo static site generator](https://gohugo.io/) and currently building out the website you see here.
 
 ## Inactive (Older/Complete)
 
 ### APO-DZ
+
 A suite of applications to facilitate community service and communication for my undergrad community service group, [Alpha Phi Omega](http://upennapo.org). The app provides native interfaces on iOS and Android to communicate with fellow brothers and to create/search/sign up for/report service projects & other chapter events.
 
 As an app to help my friends and the local Philadelphia community, APO-DZ has served as my primary point of entry for exploratory forays into unfamiliar technologies:
 
-####  Android app
-* About: https://ronaldsmartin.github.io/APO-DZ-Android/
-* Repo on GitHub: https://github.com/ronaldsmartin/APO-DZ-Android
+#### Android app
+
+- About: https://ronaldsmartin.github.io/APO-DZ-Android/
+- Repo on GitHub: https://github.com/ronaldsmartin/APO-DZ-Android
 
 [<img src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png" width="250" alt="Get it on Google Play">](https://play.google.com/store/apps/details?id=org.upennapo.app&utm_source=global_co&utm_medium=prtnr&utm_content=Mar2515&utm_campaign=PartBadge&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1)
 
+#### iPhone app
 
-####  iPhone app
-* Repo on GitHub: https://github.com/ronaldsmartin/APO-DZ-iOS
+- Repo on GitHub: https://github.com/ronaldsmartin/APO-DZ-iOS
 
 [![Get it on the App Store](https://linkmaker.itunes.apple.com/htmlResources/assets/en_us//images/web/linkmaker/badge_appstore-lrg.svg)](https://itunes.apple.com/us/app/apo-dz/id862246150?mt=8&uo=4)
 
-####  Google Apps Script
+#### Google Apps Script
+
 The API that makes this possible [is a Gist here on GitHub](https://gist.github.com/ronaldsmartin/47f5239ab1834c47088e).
 
-####  APO Status Checker
-* Use it: https://ronaldsmartin.github.io/apo-status/
-* Repo on GitHub: https://github.com/ronaldsmartin/apo-status
+#### APO Status Checker
+
+- Use it: https://ronaldsmartin.github.io/apo-status/
+- Repo on GitHub: https://github.com/ronaldsmartin/apo-status
 
 An almost-complete Angular.js webapp to check a specific brother's membership status without sifting through the APO Spreadsheet. I'm learning Angular as I go and hope to branch out into some data visualization with D3.
 
-####  Other
-* a prototype web version built using Google Polymer web components is unfortunately not public because of private brother data
-* a Windows Phone version is planned but not currently in progress
+#### Other
+
+- a prototype web version built using Google Polymer web components is unfortunately not public because of private brother data
+- a Windows Phone version is planned but not currently in progress
 
 ### Mater Dolorosa App
+
 Native Android app for my parish. Currently, it uses the current date and time to provide up-to-date information about service times and office hours, as well as easing access to appropriate personnel. Future plans involve creating a dashboard for current and future events, but that entails setting up a backend somewhere and more careful planning.
 
-* Repo on GitHub: https://github.com/ronaldsmartin/mater-dolorosa-android
-
+- Repo on GitHub: https://github.com/ronaldsmartin/mater-dolorosa-android
 
 ### Name Formatter for APO Update Forms
-The backend of the APO spreadsheet is built upon a network of Google Sheets, Forms, and update scripts created by my awesome robotics-master roommate, Dean (@turniphead). These forms require a specific format for brother names that is inconvenient to produce without a programmer's text editor (three cheers for regexps!). This simple webapp solves that problem.
-* Check it out: https://ronaldsmartin.github.io/APO-DZ-Form-Name-Formatter/
-* Repo on GitHub: https://github.com/ronaldsmartin/APO-DZ-Form-Name-Formatter
 
+The backend of the APO spreadsheet is built upon a network of Google Sheets, Forms, and update scripts created by my awesome robotics-master roommate, Dean (@turniphead). These forms require a specific format for brother names that is inconvenient to produce without a programmer's text editor (three cheers for regexps!). This simple webapp solves that problem.
+
+- Check it out: https://ronaldsmartin.github.io/APO-DZ-Form-Name-Formatter/
+- Repo on GitHub: https://github.com/ronaldsmartin/APO-DZ-Form-Name-Formatter
 
 ### Comegys Reporter
+
 A proof-of-concept native Android app for student behavior reporting. Built for the [Comegys Elementary School](http://webgui.phila.k12.pa.us/schools/c/comegys) in Philadelphia during the course of Penn's [CIS 350](http://www.cis.upenn.edu/~cdmurphy/cis350/), the app allows teachers to create, save, and manage student behavior reports in a cloud database hosted by Parse.
-* Repo on GitHub: https://github.com/ronaldsmartin/Comegys-Behavior-Android
+
+- Repo on GitHub: https://github.com/ronaldsmartin/Comegys-Behavior-Android
 
 ### Automated Theorem Deducers
+
 As a big fan of recursion and functional programming, one of my interests has been working on modeling proof systems in Haskell. The original version for Gentzen's sequent calculus was built during Penn's [FA'13 Advanced Programming course](http://www.seas.upenn.edu/~cis552/13fa/index.html) with my partner, Anne Foster. Code will be open-sourced as time permits.
 
 ### Chores-at-4030
+
 A Ruby on Rails webapp built as a class project for CIS 196 designed to let houses keep track of their chores.
-* Check it out here: http://chores-at-4030.herokuapp.com/
-* Repo on GitHub: https://github.com/ronaldsmartin/chores-at-403
+
+- Check it out here: http://chores-at-4030.herokuapp.com/
+- Repo on GitHub: https://github.com/ronaldsmartin/chores-at-403

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,12 +1,12 @@
-import rss from '@astrojs/rss';
-import { getCollection } from 'astro:content';
-import { siteConfig } from '../data/site';
-import { getPostUrl } from '../utils/postUrl';
-import type { APIContext } from 'astro';
+import rss from "@astrojs/rss";
+import { getCollection } from "astro:content";
+import { siteConfig } from "../data/site";
+import { getPostUrl } from "../utils/postUrl";
+import type { APIContext } from "astro";
 
 export async function GET(context: APIContext) {
-  const posts = (await getCollection('blog')).sort(
-    (a, b) => b.data.date.valueOf() - a.data.date.valueOf()
+  const posts = (await getCollection("blog")).sort(
+    (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
   );
 
   return rss({

--- a/src/utils/excerpt.ts
+++ b/src/utils/excerpt.ts
@@ -2,32 +2,32 @@
 export function getExcerpt(content: string, wordCount = 70): string {
   const text = content
     // Remove HTML tags
-    .replace(/<[^>]*>/g, '')
+    .replace(/<[^>]*>/g, "")
     // Remove images: ![alt](url)
-    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, "")
     // Convert links to just text: [text](url) → text
-    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
     // Remove reference-style links: [text][ref]
-    .replace(/\[([^\]]*)\]\[[^\]]*\]/g, '$1')
+    .replace(/\[([^\]]*)\]\[[^\]]*\]/g, "$1")
     // Remove headings: # text → text
-    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/^#{1,6}\s+/gm, "")
     // Remove blockquote markers
-    .replace(/^>\s?/gm, '')
+    .replace(/^>\s?/gm, "")
     // Remove bold/italic markers
-    .replace(/\*{1,3}([^*]+)\*{1,3}/g, '$1')
-    .replace(/_{1,3}([^_]+)_{1,3}/g, '$1')
+    .replace(/\*{1,3}([^*]+)\*{1,3}/g, "$1")
+    .replace(/_{1,3}([^_]+)_{1,3}/g, "$1")
     // Remove inline code backticks
-    .replace(/`([^`]+)`/g, '$1')
+    .replace(/`([^`]+)`/g, "$1")
     // Remove fenced code block markers
-    .replace(/^```[\s\S]*?^```/gm, '')
+    .replace(/^```[\s\S]*?^```/gm, "")
     // Remove horizontal rules
-    .replace(/^[-*_]{3,}\s*$/gm, '')
+    .replace(/^[-*_]{3,}\s*$/gm, "")
     // Remove shortcode-like patterns
-    .replace(/\{\{[^}]*\}\}/g, '')
+    .replace(/\{\{[^}]*\}\}/g, "")
     // Collapse whitespace
-    .replace(/\s+/g, ' ')
+    .replace(/\s+/g, " ")
     .trim();
 
   const words = text.split(/\s+/).slice(0, wordCount);
-  return words.join(' ') + '...';
+  return words.join(" ") + "...";
 }

--- a/src/utils/featuredImage.ts
+++ b/src/utils/featuredImage.ts
@@ -6,9 +6,9 @@ export function getFeaturedImageUrl(
 ): string | null {
   if (!featured) return null;
 
-  if (featuredpath === 'date') {
+  if (featuredpath === "date") {
     const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const month = String(date.getMonth() + 1).padStart(2, "0");
     return `/img/${year}/${month}/${featured}`;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,7 +21,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@astrojs/compiler@npm:^2.13.0":
+"@astrojs/compiler@npm:^2.0.0, @astrojs/compiler@npm:^2.13.0, @astrojs/compiler@npm:^2.9.1":
   version: 2.13.1
   resolution: "@astrojs/compiler@npm:2.13.1"
   checksum: 10c0/83d85c30c8b1bd6d2382f1bc3d99126732838dc747e3a9defa55f726ccc2276c710e6af81bfb68d8fb17fde452c69cf0187cb1d2f8eb022764f1ccc4cf3a3db1
@@ -629,6 +629,113 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.8.0, @eslint-community/eslint-utils@npm:^4.9.1":
+  version: 4.9.1
+  resolution: "@eslint-community/eslint-utils@npm:4.9.1"
+  dependencies:
+    eslint-visitor-keys: "npm:^3.4.3"
+  peerDependencies:
+    eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+  checksum: 10c0/dc4ab5e3e364ef27e33666b11f4b86e1a6c1d7cbf16f0c6ff87b1619b3562335e9201a3d6ce806221887ff780ec9d828962a290bb910759fd40a674686503f02
+  languageName: node
+  linkType: hard
+
+"@eslint-community/regexpp@npm:^4.12.2":
+  version: 4.12.2
+  resolution: "@eslint-community/regexpp@npm:4.12.2"
+  checksum: 10c0/fddcbc66851b308478d04e302a4d771d6917a0b3740dc351513c0da9ca2eab8a1adf99f5e0aa7ab8b13fa0df005c81adeee7e63a92f3effd7d367a163b721c2d
+  languageName: node
+  linkType: hard
+
+"@eslint/config-array@npm:^0.23.2":
+  version: 0.23.2
+  resolution: "@eslint/config-array@npm:0.23.2"
+  dependencies:
+    "@eslint/object-schema": "npm:^3.0.2"
+    debug: "npm:^4.3.1"
+    minimatch: "npm:^10.2.1"
+  checksum: 10c0/95d7506c3fcb13c9a477f0fd501d552a4f136425fdf41a57058565d4730d888c78a467f8cefee92c7ac911b2c9da72629cb90507bc943cb2e5ae7bcdcdd2b759
+  languageName: node
+  linkType: hard
+
+"@eslint/config-helpers@npm:^0.5.2":
+  version: 0.5.2
+  resolution: "@eslint/config-helpers@npm:0.5.2"
+  dependencies:
+    "@eslint/core": "npm:^1.1.0"
+  checksum: 10c0/0dc65bc5dd80441afbf5007cae702a5d9dd08893e95fed702a463366cf9ce2f4fd90adb09f9012cb4fcc9783d897ccb739067b1b8a5942f4c8288a6efb396d58
+  languageName: node
+  linkType: hard
+
+"@eslint/core@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@eslint/core@npm:1.1.0"
+  dependencies:
+    "@types/json-schema": "npm:^7.0.15"
+  checksum: 10c0/0f875d6f24fbf67cc796e01c2ca82884f755488052ed84183e56377c5b90fe10b491a26e600642db4daea1d5d8ab7906ec12f2bd5cbdb5004b0ef73c802bdb57
+  languageName: node
+  linkType: hard
+
+"@eslint/js@npm:^10.0.1":
+  version: 10.0.1
+  resolution: "@eslint/js@npm:10.0.1"
+  peerDependencies:
+    eslint: ^10.0.0
+  peerDependenciesMeta:
+    eslint:
+      optional: true
+  checksum: 10c0/9f3fcaf71ba7fdf65d82e8faad6ecfe97e11801cc3c362b306a88ea1ed1344ae0d35330dddb0e8ad18f010f6687a70b75491b9e01c8af57acd7987cee6b3ec6c
+  languageName: node
+  linkType: hard
+
+"@eslint/object-schema@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "@eslint/object-schema@npm:3.0.2"
+  checksum: 10c0/5f8b2e264bbde6f7c86f6846a2f04cb6e3f52df49e3cce0659cea31d7f7410bb5ac681f6f910294f8362e427054665d2c5b5c794580cab6b0d5a1c177e131ec1
+  languageName: node
+  linkType: hard
+
+"@eslint/plugin-kit@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "@eslint/plugin-kit@npm:0.6.0"
+  dependencies:
+    "@eslint/core": "npm:^1.1.0"
+    levn: "npm:^0.4.1"
+  checksum: 10c0/1d726338a9f4537fe2848796c44d801093ea3a99166dbc45bc6f7742fa2ad74ce0c2f114092ce4460710a9dfe5ea6e3500446f81842388bf81328c97c3a43d9d
+  languageName: node
+  linkType: hard
+
+"@humanfs/core@npm:^0.19.1":
+  version: 0.19.1
+  resolution: "@humanfs/core@npm:0.19.1"
+  checksum: 10c0/aa4e0152171c07879b458d0e8a704b8c3a89a8c0541726c6b65b81e84fd8b7564b5d6c633feadc6598307d34564bd53294b533491424e8e313d7ab6c7bc5dc67
+  languageName: node
+  linkType: hard
+
+"@humanfs/node@npm:^0.16.6":
+  version: 0.16.7
+  resolution: "@humanfs/node@npm:0.16.7"
+  dependencies:
+    "@humanfs/core": "npm:^0.19.1"
+    "@humanwhocodes/retry": "npm:^0.4.0"
+  checksum: 10c0/9f83d3cf2cfa37383e01e3cdaead11cd426208e04c44adcdd291aa983aaf72d7d3598844d2fe9ce54896bb1bf8bd4b56883376611c8905a19c44684642823f30
+  languageName: node
+  linkType: hard
+
+"@humanwhocodes/module-importer@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@humanwhocodes/module-importer@npm:1.0.1"
+  checksum: 10c0/909b69c3b86d482c26b3359db16e46a32e0fb30bd306a3c176b8313b9e7313dba0f37f519de6aa8b0a1921349e505f259d19475e123182416a506d7f87e7f529
+  languageName: node
+  linkType: hard
+
+"@humanwhocodes/retry@npm:^0.4.0, @humanwhocodes/retry@npm:^0.4.2":
+  version: 0.4.3
+  resolution: "@humanwhocodes/retry@npm:0.4.3"
+  checksum: 10c0/3775bb30087d4440b3f7406d5a057777d90e4b9f435af488a4923ef249e93615fb78565a85f173a186a076c7706a81d0d57d563a2624e4de2c5c9c66c486ce42
+  languageName: node
+  linkType: hard
+
 "@img/colour@npm:^1.0.0":
   version: 1.0.0
   resolution: "@img/colour@npm:1.0.0"
@@ -865,10 +972,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.5.5":
+"@jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.5.5":
   version: 1.5.5
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
   checksum: 10c0/f9e538f302b63c0ebc06eecb1dd9918dd4289ed36147a0ddce35d6ea4d7ebbda243cda7b2213b6a5e1d8087a298d5cf630fb2bd39329cdecb82017023f6081a0
+  languageName: node
+  linkType: hard
+
+"@nodelib/fs.scandir@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@nodelib/fs.scandir@npm:2.1.5"
+  dependencies:
+    "@nodelib/fs.stat": "npm:2.0.5"
+    run-parallel: "npm:^1.1.9"
+  checksum: 10c0/732c3b6d1b1e967440e65f284bd06e5821fedf10a1bea9ed2bb75956ea1f30e08c44d3def9d6a230666574edbaf136f8cfd319c14fd1f87c66e6a44449afb2eb
+  languageName: node
+  linkType: hard
+
+"@nodelib/fs.stat@npm:2.0.5, @nodelib/fs.stat@npm:^2.0.2":
+  version: 2.0.5
+  resolution: "@nodelib/fs.stat@npm:2.0.5"
+  checksum: 10c0/88dafe5e3e29a388b07264680dc996c17f4bda48d163a9d4f5c1112979f0ce8ec72aa7116122c350b4e7976bc5566dc3ddb579be1ceaacc727872eb4ed93926d
+  languageName: node
+  linkType: hard
+
+"@nodelib/fs.walk@npm:^1.2.3":
+  version: 1.2.8
+  resolution: "@nodelib/fs.walk@npm:1.2.8"
+  dependencies:
+    "@nodelib/fs.scandir": "npm:2.1.5"
+    fastq: "npm:^1.6.0"
+  checksum: 10c0/db9de047c3bb9b51f9335a7bb46f4fcfb6829fb628318c12115fbaf7d369bfce71c15b103d1fc3b464812d936220ee9bc1c8f762d032c9f6be9acc99249095b1
   languageName: node
   linkType: hard
 
@@ -898,6 +1032,13 @@ __metadata:
   version: 1.1.0
   resolution: "@oslojs/encoding@npm:1.1.0"
   checksum: 10c0/5553a0974dca60e1a8b247b7b97abcb141cc7ee4e22444f424a07921d6a5f76a43c316f3ee669222787fdef6549f8749cc6d68ff5a631e2542521c56fe36417f
+  languageName: node
+  linkType: hard
+
+"@pkgr/core@npm:^0.2.9":
+  version: 0.2.9
+  resolution: "@pkgr/core@npm:0.2.9"
+  checksum: 10c0/ac8e4e8138b1a7a4ac6282873aef7389c352f1f8b577b4850778f5182e4a39a5241facbe48361fec817f56d02b51691b383010843fb08b34a8e8ea3614688fd5
   languageName: node
   linkType: hard
 
@@ -1169,7 +1310,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:1.0.8, @types/estree@npm:^1.0.0":
+"@types/esrecurse@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "@types/esrecurse@npm:4.3.1"
+  checksum: 10c0/90dad74d5da3ad27606d8e8e757322f33171cfeaa15ad558b615cf71bb2a516492d18f55f4816384685a3eb2412142e732bbae9a4a7cd2cf3deb7572aa4ebe03
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:1.0.8, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.6, @types/estree@npm:^1.0.8":
   version: 1.0.8
   resolution: "@types/estree@npm:1.0.8"
   checksum: 10c0/39d34d1afaa338ab9763f37ad6066e3f349444f9052b9676a7cc0252ef9485a41c6d81c9c4e0d26e9077993354edf25efc853f3224dd4b447175ef62bdcc86a5
@@ -1182,6 +1330,13 @@ __metadata:
   dependencies:
     "@types/unist": "npm:*"
   checksum: 10c0/3249781a511b38f1d330fd1e3344eed3c4e7ea8eff82e835d35da78e637480d36fad37a78be5a7aed8465d237ad0446abc1150859d0fde395354ea634decf9f7
+  languageName: node
+  linkType: hard
+
+"@types/json-schema@npm:^7.0.15":
+  version: 7.0.15
+  resolution: "@types/json-schema@npm:7.0.15"
+  checksum: 10c0/a996a745e6c5d60292f36731dd41341339d4eeed8180bb09226e5c8d23759067692b1d88e5d91d72ee83dfc00d3aca8e7bd43ea120516c17922cbcb7c3e252db
   languageName: node
   linkType: hard
 
@@ -1239,6 +1394,141 @@ __metadata:
   version: 3.0.3
   resolution: "@types/unist@npm:3.0.3"
   checksum: 10c0/2b1e4adcab78388e088fcc3c0ae8700f76619dbcb4741d7d201f87e2cb346bfc29a89003cfea2d76c996e1061452e14fcd737e8b25aacf949c1f2d6b2bc3dd60
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/eslint-plugin@npm:8.56.0":
+  version: 8.56.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.56.0"
+  dependencies:
+    "@eslint-community/regexpp": "npm:^4.12.2"
+    "@typescript-eslint/scope-manager": "npm:8.56.0"
+    "@typescript-eslint/type-utils": "npm:8.56.0"
+    "@typescript-eslint/utils": "npm:8.56.0"
+    "@typescript-eslint/visitor-keys": "npm:8.56.0"
+    ignore: "npm:^7.0.5"
+    natural-compare: "npm:^1.4.0"
+    ts-api-utils: "npm:^2.4.0"
+  peerDependencies:
+    "@typescript-eslint/parser": ^8.56.0
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 10c0/26e56d14562b3d2d34b366859ec56668fdac909d6ea534451cdb4267846ff50dcccd0026a4eba71ca41f7c8bdef30ef1356620c1ff2363ad64bd8fad33a72b19
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/parser@npm:8.56.0":
+  version: 8.56.0
+  resolution: "@typescript-eslint/parser@npm:8.56.0"
+  dependencies:
+    "@typescript-eslint/scope-manager": "npm:8.56.0"
+    "@typescript-eslint/types": "npm:8.56.0"
+    "@typescript-eslint/typescript-estree": "npm:8.56.0"
+    "@typescript-eslint/visitor-keys": "npm:8.56.0"
+    debug: "npm:^4.4.3"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 10c0/f3a29c6fdc4e0d1a1e7ddb9909ab839c2f67591933e432c10f44aabb69ae2229f8d2072a220f63b70618cc35c67ff53de0ed110be86b33f4f354c19993f764cb
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/project-service@npm:8.56.0":
+  version: 8.56.0
+  resolution: "@typescript-eslint/project-service@npm:8.56.0"
+  dependencies:
+    "@typescript-eslint/tsconfig-utils": "npm:^8.56.0"
+    "@typescript-eslint/types": "npm:^8.56.0"
+    debug: "npm:^4.4.3"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 10c0/8302dc30ad8c0342137998ea872782cdd673f9e7ec4b244eeb0976915b86d6c44ef55485e2cdac2987dbf309d3663aaf293c85e88326093fc7656b51432369f6
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/scope-manager@npm:8.56.0, @typescript-eslint/scope-manager@npm:^7.0.0 || ^8.0.0":
+  version: 8.56.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.56.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.56.0"
+    "@typescript-eslint/visitor-keys": "npm:8.56.0"
+  checksum: 10c0/898b705295e0a4081702a52f98e0d1e50f8047900becd087b232bc71f8af2b87ed70a065bed0076a26abec8f4e5c6bb4a3a0de33b7ea0e3704ecdc7487043b57
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/tsconfig-utils@npm:8.56.0, @typescript-eslint/tsconfig-utils@npm:^8.56.0":
+  version: 8.56.0
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.56.0"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 10c0/20f48af8b497d8a730dcac3724314b4f49ecc436f8871f3e17f5193d83e7d290c8838a126971767cd011208969bc4ff0f4bddc40eac167348c88d29fdb379c8b
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/type-utils@npm:8.56.0":
+  version: 8.56.0
+  resolution: "@typescript-eslint/type-utils@npm:8.56.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.56.0"
+    "@typescript-eslint/typescript-estree": "npm:8.56.0"
+    "@typescript-eslint/utils": "npm:8.56.0"
+    debug: "npm:^4.4.3"
+    ts-api-utils: "npm:^2.4.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 10c0/4da61c36fa46f9d21a519a06b4ea6c91e9fa8a8e420fede41fb5d0f29866faa11641562b6e01c221ca6ec86bc0c3ecd7b8f11fc85b92277c3fd450ffc8fa2522
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:8.56.0, @typescript-eslint/types@npm:^7.0.0 || ^8.0.0, @typescript-eslint/types@npm:^7.7.1 || ^8, @typescript-eslint/types@npm:^8.56.0":
+  version: 8.56.0
+  resolution: "@typescript-eslint/types@npm:8.56.0"
+  checksum: 10c0/5deb4ebf5fa62f9f927f6aa45f7245aa03567e88941cd76e7b083175fd59fc40368a804ba7ff7581eac75706e42ddd5c77d2a60d6b1e76ab7865d559c9af9937
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/typescript-estree@npm:8.56.0":
+  version: 8.56.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.56.0"
+  dependencies:
+    "@typescript-eslint/project-service": "npm:8.56.0"
+    "@typescript-eslint/tsconfig-utils": "npm:8.56.0"
+    "@typescript-eslint/types": "npm:8.56.0"
+    "@typescript-eslint/visitor-keys": "npm:8.56.0"
+    debug: "npm:^4.4.3"
+    minimatch: "npm:^9.0.5"
+    semver: "npm:^7.7.3"
+    tinyglobby: "npm:^0.2.15"
+    ts-api-utils: "npm:^2.4.0"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 10c0/cc2ba5bbfabb71c1510aea8fb8bf0d8385cabb9ca5b65a621e73f3088a91089a02aea56a9d9a31bd707593b5ba4d33d0aa2fcbdeee3cc7f4eca8226107523c28
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:8.56.0":
+  version: 8.56.0
+  resolution: "@typescript-eslint/utils@npm:8.56.0"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.9.1"
+    "@typescript-eslint/scope-manager": "npm:8.56.0"
+    "@typescript-eslint/types": "npm:8.56.0"
+    "@typescript-eslint/typescript-estree": "npm:8.56.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 10c0/49545d399345bb4d8113d1001ec60c05c7e0d28fd44cb3c75128e58a53c9bf7ae8d0680ca089a4f37ab9eea8a3ef39011fc731eb4ad8dd4ab642849d84318645
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:8.56.0":
+  version: 8.56.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.56.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.56.0"
+    eslint-visitor-keys: "npm:^5.0.0"
+  checksum: 10c0/4cb7668430042da70707ac5cad826348e808af94095aca1f3d07d39d566745a33991d3defccd1e687f1b1f8aeea52eeb47591933e962452eb51c4bcd88773c12
   languageName: node
   linkType: hard
 
@@ -1347,7 +1637,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.15.0":
+"acorn-jsx@npm:^5.3.2":
+  version: 5.3.2
+  resolution: "acorn-jsx@npm:5.3.2"
+  peerDependencies:
+    acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+  checksum: 10c0/4c54868fbef3b8d58927d5e33f0a4de35f59012fe7b12cf9dfbb345fb8f46607709e1c4431be869a23fb63c151033d84c4198fa9f79385cec34fcb1dd53974c1
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.15.0, acorn@npm:^8.16.0":
   version: 8.16.0
   resolution: "acorn@npm:8.16.0"
   bin:
@@ -1372,6 +1671,18 @@ __metadata:
     ajv:
       optional: true
   checksum: 10c0/6044310bd38c17d77549fd326bd40ce1506fa10b0794540aa130180808bf94117fac8c9b448c621512bea60e4a947278f6a978e87f10d342950c15b33ddd9271
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^6.12.4":
+  version: 6.14.0
+  resolution: "ajv@npm:6.14.0"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.1"
+    fast-json-stable-stringify: "npm:^2.0.0"
+    json-schema-traverse: "npm:^0.4.1"
+    uri-js: "npm:^4.2.2"
+  checksum: 10c0/a2bc39b0555dc9802c899f86990eb8eed6e366cddbf65be43d5aa7e4f3c4e1a199d5460fd7ca4fb3d864000dbbc049253b72faa83b3b30e641ca52cb29a68c22
   languageName: node
   linkType: hard
 
@@ -1464,6 +1775,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"astro-eslint-parser@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "astro-eslint-parser@npm:1.3.0"
+  dependencies:
+    "@astrojs/compiler": "npm:^2.0.0"
+    "@typescript-eslint/scope-manager": "npm:^7.0.0 || ^8.0.0"
+    "@typescript-eslint/types": "npm:^7.0.0 || ^8.0.0"
+    astrojs-compiler-sync: "npm:^1.0.0"
+    debug: "npm:^4.3.4"
+    entities: "npm:^6.0.0"
+    eslint-scope: "npm:^8.0.1"
+    eslint-visitor-keys: "npm:^4.0.0"
+    espree: "npm:^10.0.0"
+    fast-glob: "npm:^3.3.3"
+    is-glob: "npm:^4.0.3"
+    semver: "npm:^7.3.8"
+  checksum: 10c0/f0ad459711aebfd089880dd5580d51f24e62027bca9abd871111306f6e70e82fc64417901a1052489e1414cdb7fa312a1608dfc51de1e6d44007fc8bbf388066
+  languageName: node
+  linkType: hard
+
 "astro@npm:^5.17.1":
   version: 5.17.3
   resolution: "astro@npm:5.17.3"
@@ -1541,6 +1872,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"astrojs-compiler-sync@npm:^1.0.0":
+  version: 1.1.1
+  resolution: "astrojs-compiler-sync@npm:1.1.1"
+  dependencies:
+    synckit: "npm:^0.11.0"
+  peerDependencies:
+    "@astrojs/compiler": ">=0.27.0"
+  checksum: 10c0/d48156daf04b237bc9ad22dd5b8e852991ea6943f65a7cd3c4d93e6ee1debd6ecd5d961b1fb45892ab80017e7f85959676781daaf90f46301deeef47f16ee4d9
+  languageName: node
+  linkType: hard
+
 "axobject-query@npm:^4.1.0":
   version: 4.1.0
   resolution: "axobject-query@npm:4.1.0"
@@ -1598,6 +1940,15 @@ __metadata:
   dependencies:
     balanced-match: "npm:^4.0.2"
   checksum: 10c0/60c765e5df6fc0ceca3d5703202ae6779db61f28ea3bf93a04dbf0d50c22ef8e4644e09d0459c827077cd2d09ba8f199a04d92c36419fcf874601a5565013174
+  languageName: node
+  linkType: hard
+
+"braces@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "braces@npm:3.0.3"
+  dependencies:
+    fill-range: "npm:^7.1.1"
+  checksum: 10c0/7c6dfd30c338d2997ba77500539227b9d1f85e388a5f43220865201e407e076783d0881f2d297b9f80951b4c957fcf0b51c1d2d24227631643c3f7c284b0aa04
   languageName: node
   linkType: hard
 
@@ -1770,6 +2121,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cross-spawn@npm:^7.0.6":
+  version: 7.0.6
+  resolution: "cross-spawn@npm:7.0.6"
+  dependencies:
+    path-key: "npm:^3.1.0"
+    shebang-command: "npm:^2.0.0"
+    which: "npm:^2.0.1"
+  checksum: 10c0/053ea8b2135caff68a9e81470e845613e374e7309a47731e81639de3eaeb90c3d01af0e0b44d2ab9d50b43467223b88567dfeb3262db942dc063b9976718ffc1
+  languageName: node
+  linkType: hard
+
 "crossws@npm:^0.3.5":
   version: 0.3.5
   resolution: "crossws@npm:0.3.5"
@@ -1837,7 +2199,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.3.4, debug@npm:^4.4.0, debug@npm:^4.4.3":
+"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.4.0, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -1855,6 +2217,13 @@ __metadata:
   dependencies:
     character-entities: "npm:^2.0.0"
   checksum: 10c0/787f4c87f3b82ea342aa7c2d7b1882b6fb9511bb77f72ae44dcaabea0470bacd1e9c6a0080ab886545019fa0cb3a7109573fad6b61a362844c3a0ac52b36e4bb
+  languageName: node
+  linkType: hard
+
+"deep-is@npm:^0.1.3":
+  version: 0.1.4
+  resolution: "deep-is@npm:0.1.4"
+  checksum: 10c0/7f0ee496e0dff14a573dc6127f14c95061b448b87b995fc96c017ce0a1e66af1675e73f1d6064407975bc4ea6ab679497a29fff7b5b9c4e99cb10797c1ad0b4c
   languageName: node
   linkType: hard
 
@@ -2223,10 +2592,192 @@ __metadata:
   languageName: node
   linkType: hard
 
+"escape-string-regexp@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "escape-string-regexp@npm:4.0.0"
+  checksum: 10c0/9497d4dd307d845bd7f75180d8188bb17ea8c151c1edbf6b6717c100e104d629dc2dfb687686181b0f4b7d732c7dfdc4d5e7a8ff72de1b0ca283a75bbb3a9cd9
+  languageName: node
+  linkType: hard
+
 "escape-string-regexp@npm:^5.0.0":
   version: 5.0.0
   resolution: "escape-string-regexp@npm:5.0.0"
   checksum: 10c0/6366f474c6f37a802800a435232395e04e9885919873e382b157ab7e8f0feb8fed71497f84a6f6a81a49aab41815522f5839112bd38026d203aea0c91622df95
+  languageName: node
+  linkType: hard
+
+"eslint-compat-utils@npm:^0.6.0":
+  version: 0.6.5
+  resolution: "eslint-compat-utils@npm:0.6.5"
+  dependencies:
+    semver: "npm:^7.5.4"
+  peerDependencies:
+    eslint: ">=6.0.0"
+  checksum: 10c0/f3519e1460ec82c6967c4b0132801924bf5c17328999014f444ec12f075b151e992d1ebf378cb8eb0b2e00b3d04e0eaac80897209121fd115f857598b4588393
+  languageName: node
+  linkType: hard
+
+"eslint-config-prettier@npm:^10.1.8":
+  version: 10.1.8
+  resolution: "eslint-config-prettier@npm:10.1.8"
+  peerDependencies:
+    eslint: ">=7.0.0"
+  bin:
+    eslint-config-prettier: bin/cli.js
+  checksum: 10c0/e1bcfadc9eccd526c240056b1e59c5cd26544fe59feb85f38f4f1f116caed96aea0b3b87868e68b3099e55caaac3f2e5b9f58110f85db893e83a332751192682
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-astro@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "eslint-plugin-astro@npm:1.6.0"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.2.0"
+    "@jridgewell/sourcemap-codec": "npm:^1.4.14"
+    "@typescript-eslint/types": "npm:^7.7.1 || ^8"
+    astro-eslint-parser: "npm:^1.3.0"
+    eslint-compat-utils: "npm:^0.6.0"
+    globals: "npm:^16.0.0"
+    postcss: "npm:^8.4.14"
+    postcss-selector-parser: "npm:^7.0.0"
+  peerDependencies:
+    eslint: ">=8.57.0"
+  checksum: 10c0/caa1bc8fae7a31cf56543e357533d0ee06d99cada18478a78c4389f5e42e658519a30349047baeb657c387c4fa5b661cb356cc3a61c2287f1969556cae0e90ed
+  languageName: node
+  linkType: hard
+
+"eslint-scope@npm:^8.0.1":
+  version: 8.4.0
+  resolution: "eslint-scope@npm:8.4.0"
+  dependencies:
+    esrecurse: "npm:^4.3.0"
+    estraverse: "npm:^5.2.0"
+  checksum: 10c0/407f6c600204d0f3705bd557f81bd0189e69cd7996f408f8971ab5779c0af733d1af2f1412066b40ee1588b085874fc37a2333986c6521669cdbdd36ca5058e0
+  languageName: node
+  linkType: hard
+
+"eslint-scope@npm:^9.1.1":
+  version: 9.1.1
+  resolution: "eslint-scope@npm:9.1.1"
+  dependencies:
+    "@types/esrecurse": "npm:^4.3.1"
+    "@types/estree": "npm:^1.0.8"
+    esrecurse: "npm:^4.3.0"
+    estraverse: "npm:^5.2.0"
+  checksum: 10c0/58327b26cd6a78693951668ce68c466a535259173d187cbd5c9d3cbe657cfd5dfaf1c01ec3176b8f6f1cf240b48d01d01e0f76ad9300682d9dd51d5d1514d4c1
+  languageName: node
+  linkType: hard
+
+"eslint-visitor-keys@npm:^3.4.3":
+  version: 3.4.3
+  resolution: "eslint-visitor-keys@npm:3.4.3"
+  checksum: 10c0/92708e882c0a5ffd88c23c0b404ac1628cf20104a108c745f240a13c332a11aac54f49a22d5762efbffc18ecbc9a580d1b7ad034bf5f3cc3307e5cbff2ec9820
+  languageName: node
+  linkType: hard
+
+"eslint-visitor-keys@npm:^4.0.0, eslint-visitor-keys@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "eslint-visitor-keys@npm:4.2.1"
+  checksum: 10c0/fcd43999199d6740db26c58dbe0c2594623e31ca307e616ac05153c9272f12f1364f5a0b1917a8e962268fdecc6f3622c1c2908b4fcc2e047a106fe6de69dc43
+  languageName: node
+  linkType: hard
+
+"eslint-visitor-keys@npm:^5.0.0, eslint-visitor-keys@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "eslint-visitor-keys@npm:5.0.1"
+  checksum: 10c0/16190bdf2cbae40a1109384c94450c526a79b0b9c3cb21e544256ed85ac48a4b84db66b74a6561d20fe6ab77447f150d711c2ad5ad74df4fcc133736bce99678
+  languageName: node
+  linkType: hard
+
+"eslint@npm:^10.0.1":
+  version: 10.0.1
+  resolution: "eslint@npm:10.0.1"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.8.0"
+    "@eslint-community/regexpp": "npm:^4.12.2"
+    "@eslint/config-array": "npm:^0.23.2"
+    "@eslint/config-helpers": "npm:^0.5.2"
+    "@eslint/core": "npm:^1.1.0"
+    "@eslint/plugin-kit": "npm:^0.6.0"
+    "@humanfs/node": "npm:^0.16.6"
+    "@humanwhocodes/module-importer": "npm:^1.0.1"
+    "@humanwhocodes/retry": "npm:^0.4.2"
+    "@types/estree": "npm:^1.0.6"
+    ajv: "npm:^6.12.4"
+    cross-spawn: "npm:^7.0.6"
+    debug: "npm:^4.3.2"
+    escape-string-regexp: "npm:^4.0.0"
+    eslint-scope: "npm:^9.1.1"
+    eslint-visitor-keys: "npm:^5.0.1"
+    espree: "npm:^11.1.1"
+    esquery: "npm:^1.7.0"
+    esutils: "npm:^2.0.2"
+    fast-deep-equal: "npm:^3.1.3"
+    file-entry-cache: "npm:^8.0.0"
+    find-up: "npm:^5.0.0"
+    glob-parent: "npm:^6.0.2"
+    ignore: "npm:^5.2.0"
+    imurmurhash: "npm:^0.1.4"
+    is-glob: "npm:^4.0.0"
+    json-stable-stringify-without-jsonify: "npm:^1.0.1"
+    minimatch: "npm:^10.2.1"
+    natural-compare: "npm:^1.4.0"
+    optionator: "npm:^0.9.3"
+  peerDependencies:
+    jiti: "*"
+  peerDependenciesMeta:
+    jiti:
+      optional: true
+  bin:
+    eslint: bin/eslint.js
+  checksum: 10c0/760de87b6ed9cd7a9b13eb68872ff057eb6d88e63ec818e297decdb2814ba80879ad0dfabb943dabaf486b5eaf6f15d446bf42116adeb88364337202db11c449
+  languageName: node
+  linkType: hard
+
+"espree@npm:^10.0.0":
+  version: 10.4.0
+  resolution: "espree@npm:10.4.0"
+  dependencies:
+    acorn: "npm:^8.15.0"
+    acorn-jsx: "npm:^5.3.2"
+    eslint-visitor-keys: "npm:^4.2.1"
+  checksum: 10c0/c63fe06131c26c8157b4083313cb02a9a54720a08e21543300e55288c40e06c3fc284bdecf108d3a1372c5934a0a88644c98714f38b6ae8ed272b40d9ea08d6b
+  languageName: node
+  linkType: hard
+
+"espree@npm:^11.1.1":
+  version: 11.1.1
+  resolution: "espree@npm:11.1.1"
+  dependencies:
+    acorn: "npm:^8.16.0"
+    acorn-jsx: "npm:^5.3.2"
+    eslint-visitor-keys: "npm:^5.0.1"
+  checksum: 10c0/2feae74efdfb037b9e9fcb30506799845cf20900de5e441ed03e5c51aaa249f85ea5818ff177682acc0c9bfb4ac97e1965c238ee44ac7c305aab8747177bab69
+  languageName: node
+  linkType: hard
+
+"esquery@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "esquery@npm:1.7.0"
+  dependencies:
+    estraverse: "npm:^5.1.0"
+  checksum: 10c0/77d5173db450b66f3bc685d11af4c90cffeedb340f34a39af96d43509a335ce39c894fd79233df32d38f5e4e219fa0f7076f6ec90bae8320170ba082c0db4793
+  languageName: node
+  linkType: hard
+
+"esrecurse@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "esrecurse@npm:4.3.0"
+  dependencies:
+    estraverse: "npm:^5.2.0"
+  checksum: 10c0/81a37116d1408ded88ada45b9fb16dbd26fba3aadc369ce50fcaf82a0bac12772ebd7b24cd7b91fc66786bf2c1ac7b5f196bc990a473efff972f5cb338877cf5
+  languageName: node
+  linkType: hard
+
+"estraverse@npm:^5.1.0, estraverse@npm:^5.2.0":
+  version: 5.3.0
+  resolution: "estraverse@npm:5.3.0"
+  checksum: 10c0/1ff9447b96263dec95d6d67431c5e0771eb9776427421260a3e2f0fdd5d6bd4f8e37a7338f5ad2880c9f143450c9b1e4fc2069060724570a49cf9cf0312bd107
   languageName: node
   linkType: hard
 
@@ -2243,6 +2794,13 @@ __metadata:
   dependencies:
     "@types/estree": "npm:^1.0.0"
   checksum: 10c0/c12e3c2b2642d2bcae7d5aa495c60fa2f299160946535763969a1c83fc74518ffa9c2cd3a8b69ac56aea547df6a8aac25f729a342992ef0bbac5f1c73e78995d
+  languageName: node
+  linkType: hard
+
+"esutils@npm:^2.0.2":
+  version: 2.0.3
+  resolution: "esutils@npm:2.0.3"
+  checksum: 10c0/9a2fe69a41bfdade834ba7c42de4723c97ec776e40656919c62cbd13607c45e127a003f05f724a1ea55e5029a4cf2de444b13009f2af71271e42d93a637137c7
   languageName: node
   linkType: hard
 
@@ -2267,10 +2825,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-deep-equal@npm:^3.1.3":
+"fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
   checksum: 10c0/40dedc862eb8992c54579c66d914635afbec43350afbbe991235fdcb4e3a8d5af1b23ae7e79bef7d4882d0ecee06c3197488026998fb19f72dc95acff1d1b1d0
+  languageName: node
+  linkType: hard
+
+"fast-glob@npm:^3.3.3":
+  version: 3.3.3
+  resolution: "fast-glob@npm:3.3.3"
+  dependencies:
+    "@nodelib/fs.stat": "npm:^2.0.2"
+    "@nodelib/fs.walk": "npm:^1.2.3"
+    glob-parent: "npm:^5.1.2"
+    merge2: "npm:^1.3.0"
+    micromatch: "npm:^4.0.8"
+  checksum: 10c0/f6aaa141d0d3384cf73cbcdfc52f475ed293f6d5b65bfc5def368b09163a9f7e5ec2b3014d80f733c405f58e470ee0cc451c2937685045cddcdeaa24199c43fe
+  languageName: node
+  linkType: hard
+
+"fast-json-stable-stringify@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "fast-json-stable-stringify@npm:2.1.0"
+  checksum: 10c0/7f081eb0b8a64e0057b3bb03f974b3ef00135fbf36c1c710895cd9300f13c94ba809bb3a81cf4e1b03f6e5285610a61abbd7602d0652de423144dfee5a389c9b
+  languageName: node
+  linkType: hard
+
+"fast-levenshtein@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "fast-levenshtein@npm:2.0.6"
+  checksum: 10c0/111972b37338bcb88f7d9e2c5907862c280ebf4234433b95bc611e518d192ccb2d38119c4ac86e26b668d75f7f3894f4ff5c4982899afced7ca78633b08287c4
   languageName: node
   linkType: hard
 
@@ -2292,6 +2877,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fastq@npm:^1.6.0":
+  version: 1.20.1
+  resolution: "fastq@npm:1.20.1"
+  dependencies:
+    reusify: "npm:^1.0.4"
+  checksum: 10c0/e5dd725884decb1f11e5c822221d76136f239d0236f176fab80b7b8f9e7619ae57e6b4e5b73defc21e6b9ef99437ee7b545cff8e6c2c337819633712fa9d352e
+  languageName: node
+  linkType: hard
+
 "fdir@npm:^6.4.4, fdir@npm:^6.5.0":
   version: 6.5.0
   resolution: "fdir@npm:6.5.0"
@@ -2301,6 +2895,51 @@ __metadata:
     picomatch:
       optional: true
   checksum: 10c0/e345083c4306b3aed6cb8ec551e26c36bab5c511e99ea4576a16750ddc8d3240e63826cc624f5ae17ad4dc82e68a253213b60d556c11bfad064b7607847ed07f
+  languageName: node
+  linkType: hard
+
+"file-entry-cache@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "file-entry-cache@npm:8.0.0"
+  dependencies:
+    flat-cache: "npm:^4.0.0"
+  checksum: 10c0/9e2b5938b1cd9b6d7e3612bdc533afd4ac17b2fc646569e9a8abbf2eb48e5eb8e316bc38815a3ef6a1b456f4107f0d0f055a614ca613e75db6bf9ff4d72c1638
+  languageName: node
+  linkType: hard
+
+"fill-range@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "fill-range@npm:7.1.1"
+  dependencies:
+    to-regex-range: "npm:^5.0.1"
+  checksum: 10c0/b75b691bbe065472f38824f694c2f7449d7f5004aa950426a2c28f0306c60db9b880c0b0e4ed819997ffb882d1da02cfcfc819bddc94d71627f5269682edf018
+  languageName: node
+  linkType: hard
+
+"find-up@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "find-up@npm:5.0.0"
+  dependencies:
+    locate-path: "npm:^6.0.0"
+    path-exists: "npm:^4.0.0"
+  checksum: 10c0/062c5a83a9c02f53cdd6d175a37ecf8f87ea5bbff1fdfb828f04bfa021441bc7583e8ebc0872a4c1baab96221fb8a8a275a19809fb93fbc40bd69ec35634069a
+  languageName: node
+  linkType: hard
+
+"flat-cache@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "flat-cache@npm:4.0.1"
+  dependencies:
+    flatted: "npm:^3.2.9"
+    keyv: "npm:^4.5.4"
+  checksum: 10c0/2c59d93e9faa2523e4fda6b4ada749bed432cfa28c8e251f33b25795e426a1c6dbada777afb1f74fcfff33934fdbdea921ee738fcc33e71adc9d6eca984a1cfc
+  languageName: node
+  linkType: hard
+
+"flatted@npm:^3.2.9":
+  version: 3.3.3
+  resolution: "flatted@npm:3.3.3"
+  checksum: 10c0/e957a1c6b0254aa15b8cce8533e24165abd98fadc98575db082b786b5da1b7d72062b81bfdcd1da2f4d46b6ed93bec2434e62333e9b4261d79ef2e75a10dd538
   languageName: node
   linkType: hard
 
@@ -2378,6 +3017,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob-parent@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "glob-parent@npm:5.1.2"
+  dependencies:
+    is-glob: "npm:^4.0.1"
+  checksum: 10c0/cab87638e2112bee3f839ef5f6e0765057163d39c66be8ec1602f3823da4692297ad4e972de876ea17c44d652978638d2fd583c6713d0eb6591706825020c9ee
+  languageName: node
+  linkType: hard
+
+"glob-parent@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "glob-parent@npm:6.0.2"
+  dependencies:
+    is-glob: "npm:^4.0.3"
+  checksum: 10c0/317034d88654730230b3f43bb7ad4f7c90257a426e872ea0bf157473ac61c99bf5d205fad8f0185f989be8d2fa6d3c7dce1645d99d545b6ea9089c39f838e7f8
+  languageName: node
+  linkType: hard
+
 "glob@npm:^13.0.0":
   version: 13.0.6
   resolution: "glob@npm:13.0.6"
@@ -2386,6 +3043,13 @@ __metadata:
     minipass: "npm:^7.1.3"
     path-scurry: "npm:^2.0.2"
   checksum: 10c0/269c236f11a9b50357fe7a8c6aadac667e01deb5242b19c84975628f05f4438d8ee1354bb62c5d6c10f37fd59911b54d7799730633a2786660d8c69f1d18120a
+  languageName: node
+  linkType: hard
+
+"globals@npm:^16.0.0":
+  version: 16.5.0
+  resolution: "globals@npm:16.5.0"
+  checksum: 10c0/615241dae7851c8012f5aa0223005b1ed6607713d6813de0741768bd4ddc39353117648f1a7086b4b0fa45eae733f1c0a0fe369aa4e543bb63f8de8990178ea9
   languageName: node
   linkType: hard
 
@@ -2600,6 +3264,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ignore@npm:^5.2.0":
+  version: 5.3.2
+  resolution: "ignore@npm:5.3.2"
+  checksum: 10c0/f9f652c957983634ded1e7f02da3b559a0d4cc210fca3792cb67f1b153623c9c42efdc1c4121af171e295444459fc4a9201101fb041b1104a3c000bccb188337
+  languageName: node
+  linkType: hard
+
+"ignore@npm:^7.0.5":
+  version: 7.0.5
+  resolution: "ignore@npm:7.0.5"
+  checksum: 10c0/ae00db89fe873064a093b8999fe4cc284b13ef2a178636211842cceb650b9c3e390d3339191acb145d81ed5379d2074840cf0c33a20bdbd6f32821f79eb4ad5d
+  languageName: node
+  linkType: hard
+
 "import-meta-resolve@npm:^4.2.0":
   version: 4.2.0
   resolution: "import-meta-resolve@npm:4.2.0"
@@ -2637,10 +3315,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-extglob@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "is-extglob@npm:2.1.1"
+  checksum: 10c0/5487da35691fbc339700bbb2730430b07777a3c21b9ebaecb3072512dfd7b4ba78ac2381a87e8d78d20ea08affb3f1971b4af629173a6bf435ff8a4c47747912
+  languageName: node
+  linkType: hard
+
 "is-fullwidth-code-point@npm:^3.0.0":
   version: 3.0.0
   resolution: "is-fullwidth-code-point@npm:3.0.0"
   checksum: 10c0/bb11d825e049f38e04c06373a8d72782eee0205bda9d908cc550ccb3c59b99d750ff9537982e01733c1c94a58e35400661f57042158ff5e8f3e90cf936daf0fc
+  languageName: node
+  linkType: hard
+
+"is-glob@npm:^4.0.0, is-glob@npm:^4.0.1, is-glob@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "is-glob@npm:4.0.3"
+  dependencies:
+    is-extglob: "npm:^2.1.1"
+  checksum: 10c0/17fb4014e22be3bbecea9b2e3a76e9e34ff645466be702f1693e8f1ee1adac84710d0be0bd9f967d6354036fd51ab7c2741d954d6e91dae6bb69714de92c197a
   languageName: node
   linkType: hard
 
@@ -2652,6 +3346,13 @@ __metadata:
   bin:
     is-inside-container: cli.js
   checksum: 10c0/a8efb0e84f6197e6ff5c64c52890fa9acb49b7b74fed4da7c95383965da6f0fa592b4dbd5e38a79f87fc108196937acdbcd758fcefc9b140e479b39ce1fcd1cd
+  languageName: node
+  linkType: hard
+
+"is-number@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "is-number@npm:7.0.0"
+  checksum: 10c0/b4686d0d3053146095ccd45346461bc8e53b80aeb7671cc52a4de02dbbf7dc0d1d2a986e2fe4ae206984b4d34ef37e8b795ebc4f4295c978373e6575e295d811
   languageName: node
   linkType: hard
 
@@ -2671,6 +3372,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"isexe@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "isexe@npm:2.0.0"
+  checksum: 10c0/228cfa503fadc2c31596ab06ed6aa82c9976eec2bfd83397e7eaf06d0ccf42cd1dfd6743bf9aeb01aebd4156d009994c5f76ea898d2832c1fe342da923ca457d
+  languageName: node
+  linkType: hard
+
 "isexe@npm:^4.0.0":
   version: 4.0.0
   resolution: "isexe@npm:4.0.0"
@@ -2685,8 +3393,15 @@ __metadata:
     "@astrojs/check": "npm:^0.9.6"
     "@astrojs/rss": "npm:^4.0.0"
     "@astrojs/sitemap": "npm:^3.7.0"
+    "@eslint/js": "npm:^10.0.1"
     astro: "npm:^5.17.1"
+    eslint: "npm:^10.0.1"
+    eslint-config-prettier: "npm:^10.1.8"
+    eslint-plugin-astro: "npm:^1.6.0"
+    prettier: "npm:^3.8.1"
+    prettier-plugin-astro: "npm:^0.14.1"
     typescript: "npm:^5.9.3"
+    typescript-eslint: "npm:^8.56.0"
   languageName: unknown
   linkType: soft
 
@@ -2701,10 +3416,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-buffer@npm:3.0.1":
+  version: 3.0.1
+  resolution: "json-buffer@npm:3.0.1"
+  checksum: 10c0/0d1c91569d9588e7eef2b49b59851f297f3ab93c7b35c7c221e288099322be6b562767d11e4821da500f3219542b9afd2e54c5dc573107c1126ed1080f8e96d7
+  languageName: node
+  linkType: hard
+
+"json-schema-traverse@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "json-schema-traverse@npm:0.4.1"
+  checksum: 10c0/108fa90d4cc6f08243aedc6da16c408daf81793bf903e9fd5ab21983cda433d5d2da49e40711da016289465ec2e62e0324dcdfbc06275a607fe3233fde4942ce
+  languageName: node
+  linkType: hard
+
 "json-schema-traverse@npm:^1.0.0":
   version: 1.0.0
   resolution: "json-schema-traverse@npm:1.0.0"
   checksum: 10c0/71e30015d7f3d6dc1c316d6298047c8ef98a06d31ad064919976583eb61e1018a60a0067338f0f79cabc00d84af3fcc489bd48ce8a46ea165d9541ba17fb30c6
+  languageName: node
+  linkType: hard
+
+"json-stable-stringify-without-jsonify@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "json-stable-stringify-without-jsonify@npm:1.0.1"
+  checksum: 10c0/cb168b61fd4de83e58d09aaa6425ef71001bae30d260e2c57e7d09a5fd82223e2f22a042dedaab8db23b7d9ae46854b08bb1f91675a8be11c5cffebef5fb66a5
   languageName: node
   linkType: hard
 
@@ -2722,6 +3458,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"keyv@npm:^4.5.4":
+  version: 4.5.4
+  resolution: "keyv@npm:4.5.4"
+  dependencies:
+    json-buffer: "npm:3.0.1"
+  checksum: 10c0/aa52f3c5e18e16bb6324876bb8b59dd02acf782a4b789c7b2ae21107fab95fab3890ed448d4f8dba80ce05391eeac4bfabb4f02a20221342982f806fa2cf271e
+  languageName: node
+  linkType: hard
+
 "kleur@npm:^3.0.3":
   version: 3.0.3
   resolution: "kleur@npm:3.0.3"
@@ -2733,6 +3478,25 @@ __metadata:
   version: 4.1.5
   resolution: "kleur@npm:4.1.5"
   checksum: 10c0/e9de6cb49657b6fa70ba2d1448fd3d691a5c4370d8f7bbf1c2f64c24d461270f2117e1b0afe8cb3114f13bbd8e51de158c2a224953960331904e636a5e4c0f2a
+  languageName: node
+  linkType: hard
+
+"levn@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "levn@npm:0.4.1"
+  dependencies:
+    prelude-ls: "npm:^1.2.1"
+    type-check: "npm:~0.4.0"
+  checksum: 10c0/effb03cad7c89dfa5bd4f6989364bfc79994c2042ec5966cb9b95990e2edee5cd8969ddf42616a0373ac49fac1403437deaf6e9050fbbaa3546093a59b9ac94e
+  languageName: node
+  linkType: hard
+
+"locate-path@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "locate-path@npm:6.0.0"
+  dependencies:
+    p-locate: "npm:^5.0.0"
+  checksum: 10c0/d3972ab70dfe58ce620e64265f90162d247e87159b6126b01314dd67be43d50e96a50b517bce2d9452a79409c7614054c277b5232377de50416564a77ac7aad3
   languageName: node
   linkType: hard
 
@@ -2987,6 +3751,13 @@ __metadata:
   version: 2.12.2
   resolution: "mdn-data@npm:2.12.2"
   checksum: 10c0/b22443b71d70f72ccc3c6ba1608035431a8fc18c3c8fc53523f06d20e05c2ac10f9b53092759a2ca85cf02f0d37036f310b581ce03e7b99ac74d388ef8152ade
+  languageName: node
+  linkType: hard
+
+"merge2@npm:^1.3.0":
+  version: 1.4.1
+  resolution: "merge2@npm:1.4.1"
+  checksum: 10c0/254a8a4605b58f450308fc474c82ac9a094848081bf4c06778200207820e5193726dc563a0d2c16468810516a5c97d9d3ea0ca6585d23c58ccfff2403e8dbbeb
   languageName: node
   linkType: hard
 
@@ -3319,12 +4090,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.2.2":
+"micromatch@npm:^4.0.8":
+  version: 4.0.8
+  resolution: "micromatch@npm:4.0.8"
+  dependencies:
+    braces: "npm:^3.0.3"
+    picomatch: "npm:^2.3.1"
+  checksum: 10c0/166fa6eb926b9553f32ef81f5f531d27b4ce7da60e5baf8c021d043b27a388fb95e46a8038d5045877881e673f8134122b59624d5cecbd16eb50a42e7a6b5ca8
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^10.2.1, minimatch@npm:^10.2.2":
   version: 10.2.2
   resolution: "minimatch@npm:10.2.2"
   dependencies:
     brace-expansion: "npm:^5.0.2"
   checksum: 10c0/098831f2f542cb802e1f249c809008a016e1fef6b3a9eda9cf9ecb2b3d7979083951bd47c0c82fcf34330bd3b36638a493d4fa8e24cce58caf5b481de0f4e238
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^9.0.5":
+  version: 9.0.6
+  resolution: "minimatch@npm:9.0.6"
+  dependencies:
+    brace-expansion: "npm:^5.0.2"
+  checksum: 10c0/b81984f96b64b9b3c6cc7d949950290c456639bf5d89c568041b0505080cfe34102bd1d8586a4dc65878ca02e68ac425e0d8fcb7af10156694c4b8889a0c6c75
   languageName: node
   linkType: hard
 
@@ -3431,6 +4221,13 @@ __metadata:
   bin:
     nanoid: bin/nanoid.cjs
   checksum: 10c0/40e7f70b3d15f725ca072dfc4f74e81fcf1fbb02e491cf58ac0c79093adc9b0a73b152bcde57df4b79cd097e13023d7504acb38404a4da7bc1cd8e887b82fe0b
+  languageName: node
+  linkType: hard
+
+"natural-compare@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "natural-compare@npm:1.4.0"
+  checksum: 10c0/f5f9a7974bfb28a91afafa254b197f0f22c684d4a1731763dda960d2c8e375b36c7d690e0d9dc8fba774c537af14a7e979129bca23d88d052fbeb9466955e447
   languageName: node
   linkType: hard
 
@@ -3554,12 +4351,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"optionator@npm:^0.9.3":
+  version: 0.9.4
+  resolution: "optionator@npm:0.9.4"
+  dependencies:
+    deep-is: "npm:^0.1.3"
+    fast-levenshtein: "npm:^2.0.6"
+    levn: "npm:^0.4.1"
+    prelude-ls: "npm:^1.2.1"
+    type-check: "npm:^0.4.0"
+    word-wrap: "npm:^1.2.5"
+  checksum: 10c0/4afb687a059ee65b61df74dfe87d8d6815cd6883cb8b3d5883a910df72d0f5d029821f37025e4bccf4048873dbdb09acc6d303d27b8f76b1a80dd5a7d5334675
+  languageName: node
+  linkType: hard
+
+"p-limit@npm:^3.0.2":
+  version: 3.1.0
+  resolution: "p-limit@npm:3.1.0"
+  dependencies:
+    yocto-queue: "npm:^0.1.0"
+  checksum: 10c0/9db675949dbdc9c3763c89e748d0ef8bdad0afbb24d49ceaf4c46c02c77d30db4e0652ed36d0a0a7a95154335fab810d95c86153105bb73b3a90448e2bb14e1a
+  languageName: node
+  linkType: hard
+
 "p-limit@npm:^6.2.0":
   version: 6.2.0
   resolution: "p-limit@npm:6.2.0"
   dependencies:
     yocto-queue: "npm:^1.1.1"
   checksum: 10c0/448bf55a1776ca1444594d53b3c731e68cdca00d44a6c8df06a2f6e506d5bbd540ebb57b05280f8c8bff992a630ed782a69612473f769a7473495d19e2270166
+  languageName: node
+  linkType: hard
+
+"p-locate@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "p-locate@npm:5.0.0"
+  dependencies:
+    p-limit: "npm:^3.0.2"
+  checksum: 10c0/2290d627ab7903b8b70d11d384fee714b797f6040d9278932754a6860845c4d3190603a0772a663c8cb5a7b21d1b16acb3a6487ebcafa9773094edc3dfe6009a
   languageName: node
   linkType: hard
 
@@ -3624,6 +4453,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-exists@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "path-exists@npm:4.0.0"
+  checksum: 10c0/8c0bd3f5238188197dc78dced15207a4716c51cc4e3624c44fc97acf69558f5ebb9a2afff486fe1b4ee148e0c133e96c5e11a9aa5c48a3006e3467da070e5e1b
+  languageName: node
+  linkType: hard
+
+"path-key@npm:^3.1.0":
+  version: 3.1.1
+  resolution: "path-key@npm:3.1.1"
+  checksum: 10c0/748c43efd5a569c039d7a00a03b58eecd1d75f3999f5a28303d75f521288df4823bc057d8784eb72358b2895a05f29a070bc9f1f17d28226cc4e62494cc58c4c
+  languageName: node
+  linkType: hard
+
 "path-scurry@npm:^2.0.2":
   version: 2.0.2
   resolution: "path-scurry@npm:2.0.2"
@@ -3648,7 +4491,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4":
+"picomatch@npm:^2.0.4, picomatch@npm:^2.3.1":
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 10c0/26c02b8d06f03206fc2ab8d16f19960f2ff9e81a658f831ecb656d8f17d9edc799e8364b1f4a7873e89d9702dff96204be0fa26fe4181f6843f040f819dac4be
@@ -3662,7 +4505,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.3":
+"postcss-selector-parser@npm:^7.0.0":
+  version: 7.1.1
+  resolution: "postcss-selector-parser@npm:7.1.1"
+  dependencies:
+    cssesc: "npm:^3.0.0"
+    util-deprecate: "npm:^1.0.2"
+  checksum: 10c0/02d3b1589ddcddceed4b583b098b95a7266dacd5135f041e5d913ebb48e874fd333a36e564cc9a2ec426a464cb18db11cb192ac76247aced5eba8c951bf59507
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.4.14, postcss@npm:^8.5.3":
   version: 8.5.6
   resolution: "postcss@npm:8.5.6"
   dependencies:
@@ -3673,7 +4526,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.5.0":
+"prelude-ls@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "prelude-ls@npm:1.2.1"
+  checksum: 10c0/b00d617431e7886c520a6f498a2e14c75ec58f6d93ba48c3b639cf241b54232d90daa05d83a9e9b9fef6baa63cb7e1e4602c2372fea5bc169668401eb127d0cd
+  languageName: node
+  linkType: hard
+
+"prettier-plugin-astro@npm:^0.14.1":
+  version: 0.14.1
+  resolution: "prettier-plugin-astro@npm:0.14.1"
+  dependencies:
+    "@astrojs/compiler": "npm:^2.9.1"
+    prettier: "npm:^3.0.0"
+    sass-formatter: "npm:^0.7.6"
+  checksum: 10c0/f812607d422ff36df1bf58534a96590a861dedf41e70f8f36fa9546b91def65b17f4507e1c9212dab56cbbae2f4ab5ff6e7e31370b9198261360c6444daa297c
+  languageName: node
+  linkType: hard
+
+"prettier@npm:^3.0.0, prettier@npm:^3.5.0, prettier@npm:^3.8.1":
   version: 3.8.1
   resolution: "prettier@npm:3.8.1"
   bin:
@@ -3720,6 +4591,20 @@ __metadata:
   version: 7.1.0
   resolution: "property-information@npm:7.1.0"
   checksum: 10c0/e0fe22cff26103260ad0e82959229106563fa115a54c4d6c183f49d88054e489cc9f23452d3ad584179dc13a8b7b37411a5df873746b5e4086c865874bfa968e
+  languageName: node
+  linkType: hard
+
+"punycode@npm:^2.1.0":
+  version: 2.3.1
+  resolution: "punycode@npm:2.3.1"
+  checksum: 10c0/14f76a8206bc3464f794fb2e3d3cc665ae416c01893ad7a02b23766eb07159144ee612ad67af5e84fa4479ccfe67678c4feb126b0485651b302babf66f04f9e9
+  languageName: node
+  linkType: hard
+
+"queue-microtask@npm:^1.2.2":
+  version: 1.2.3
+  resolution: "queue-microtask@npm:1.2.3"
+  checksum: 10c0/900a93d3cdae3acd7d16f642c29a642aea32c2026446151f0778c62ac089d4b8e6c986811076e1ae180a694cedf077d453a11b58ff0a865629a4f82ab558e102
   languageName: node
   linkType: hard
 
@@ -3956,6 +4841,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"reusify@npm:^1.0.4":
+  version: 1.1.0
+  resolution: "reusify@npm:1.1.0"
+  checksum: 10c0/4eff0d4a5f9383566c7d7ec437b671cc51b25963bd61bf127c3f3d3f68e44a026d99b8d2f1ad344afff8d278a8fe70a8ea092650a716d22287e8bef7126bb2fa
+  languageName: node
+  linkType: hard
+
 "rollup@npm:^4.34.9":
   version: 4.58.0
   resolution: "rollup@npm:4.58.0"
@@ -4046,10 +4938,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"run-parallel@npm:^1.1.9":
+  version: 1.2.0
+  resolution: "run-parallel@npm:1.2.0"
+  dependencies:
+    queue-microtask: "npm:^1.2.2"
+  checksum: 10c0/200b5ab25b5b8b7113f9901bfe3afc347e19bb7475b267d55ad0eb86a62a46d77510cb0f232507c9e5d497ebda569a08a9867d0d14f57a82ad5564d991588b39
+  languageName: node
+  linkType: hard
+
+"s.color@npm:0.0.15":
+  version: 0.0.15
+  resolution: "s.color@npm:0.0.15"
+  checksum: 10c0/50532b1307a65ac5e1076f5b556f5ce7e5c8ea3ff1c73810a226a0109efe84ff196e10017cd906c78a87d9600a26ca7016ac78896232aa05949a98bf2100adf1
+  languageName: node
+  linkType: hard
+
 "safer-buffer@npm:>= 2.1.2 < 3.0.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: 10c0/7e3c8b2e88a1841c9671094bbaeebd94448111dd90a81a1f606f3f67708a6ec57763b3b47f06da09fc6054193e0e6709e77325415dc8422b04497a8070fa02d4
+  languageName: node
+  linkType: hard
+
+"sass-formatter@npm:^0.7.6":
+  version: 0.7.9
+  resolution: "sass-formatter@npm:0.7.9"
+  dependencies:
+    suf-log: "npm:^2.5.3"
+  checksum: 10c0/172eb326121ace1a48e689a1419efab2d780623631d106ac306ac2a055e96813bda36044f20bc4cc28d761427efc136a08d07153d1b8a8ccf0a032dca5fdce3c
   languageName: node
   linkType: hard
 
@@ -4060,7 +4977,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.5, semver@npm:^7.3.8, semver@npm:^7.6.2, semver@npm:^7.7.3":
+"semver@npm:^7.3.5, semver@npm:^7.3.8, semver@npm:^7.5.4, semver@npm:^7.6.2, semver@npm:^7.7.3":
   version: 7.7.4
   resolution: "semver@npm:7.7.4"
   bin:
@@ -4150,6 +5067,22 @@ __metadata:
     "@img/sharp-win32-x64":
       optional: true
   checksum: 10c0/fd79e29df0597a7d5704b8461c51f944ead91a5243691697be6e8243b966402beda53ddc6f0a53b96ea3cb8221f0b244aa588114d3ebf8734fb4aefd41ab802f
+  languageName: node
+  linkType: hard
+
+"shebang-command@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "shebang-command@npm:2.0.0"
+  dependencies:
+    shebang-regex: "npm:^3.0.0"
+  checksum: 10c0/a41692e7d89a553ef21d324a5cceb5f686d1f3c040759c50aab69688634688c5c327f26f3ecf7001ebfd78c01f3c7c0a11a7c8bfd0a8bc9f6240d4f40b224e4e
+  languageName: node
+  linkType: hard
+
+"shebang-regex@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "shebang-regex@npm:3.0.0"
+  checksum: 10c0/1dbed0726dd0e1152a92696c76c7f06084eb32a90f0528d11acd764043aacf76994b2fb30aa1291a21bd019d6699164d048286309a278855ee7bec06cf6fb690
   languageName: node
   linkType: hard
 
@@ -4312,6 +5245,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"suf-log@npm:^2.5.3":
+  version: 2.5.3
+  resolution: "suf-log@npm:2.5.3"
+  dependencies:
+    s.color: "npm:0.0.15"
+  checksum: 10c0/67edce59cce30964b2bec4f2e726c980c1e83d266adb186e3a92f8d267916cd2ae38f8e5aa14af9df675837708d93b212a7e3241505abec948d7fd3705781f0a
+  languageName: node
+  linkType: hard
+
 "svgo@npm:^4.0.0":
   version: 4.0.0
   resolution: "svgo@npm:4.0.0"
@@ -4326,6 +5268,15 @@ __metadata:
   bin:
     svgo: ./bin/svgo.js
   checksum: 10c0/2b01c910d59d10bb15e17714181a8fa96531b09a4e2cf2ca1abe24dbcb8400725b6d542d6e456c62222546e334d5b344799c170c5b6be0c48e31b02c23297275
+  languageName: node
+  linkType: hard
+
+"synckit@npm:^0.11.0":
+  version: 0.11.12
+  resolution: "synckit@npm:0.11.12"
+  dependencies:
+    "@pkgr/core": "npm:^0.2.9"
+  checksum: 10c0/cc4d446806688ae0d728ae7bb3f53176d065cf9536647fb85bdd721dcefbd7bf94874df6799ff61580f2b03a392659219b778a9254ad499f9a1f56c34787c235
   languageName: node
   linkType: hard
 
@@ -4366,6 +5317,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"to-regex-range@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "to-regex-range@npm:5.0.1"
+  dependencies:
+    is-number: "npm:^7.0.0"
+  checksum: 10c0/487988b0a19c654ff3e1961b87f471702e708fa8a8dd02a298ef16da7206692e8552a0250e8b3e8759270f62e9d8314616f6da274734d3b558b1fc7b7724e892
+  languageName: node
+  linkType: hard
+
 "trim-lines@npm:^3.0.0":
   version: 3.0.1
   resolution: "trim-lines@npm:3.0.1"
@@ -4377,6 +5337,15 @@ __metadata:
   version: 2.2.0
   resolution: "trough@npm:2.2.0"
   checksum: 10c0/58b671fc970e7867a48514168894396dd94e6d9d6456aca427cc299c004fe67f35ed7172a36449086b2edde10e78a71a284ec0076809add6834fb8f857ccb9b0
+  languageName: node
+  linkType: hard
+
+"ts-api-utils@npm:^2.4.0":
+  version: 2.4.0
+  resolution: "ts-api-utils@npm:2.4.0"
+  peerDependencies:
+    typescript: ">=4.8.4"
+  checksum: 10c0/ed185861aef4e7124366a3f6561113557a57504267d4d452a51e0ba516a9b6e713b56b4aeaab9fa13de9db9ab755c65c8c13a777dba9133c214632cb7b65c083
   languageName: node
   linkType: hard
 
@@ -4401,6 +5370,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type-check@npm:^0.4.0, type-check@npm:~0.4.0":
+  version: 0.4.0
+  resolution: "type-check@npm:0.4.0"
+  dependencies:
+    prelude-ls: "npm:^1.2.1"
+  checksum: 10c0/7b3fd0ed43891e2080bf0c5c504b418fbb3e5c7b9708d3d015037ba2e6323a28152ec163bcb65212741fa5d2022e3075ac3c76440dbd344c9035f818e8ecee58
+  languageName: node
+  linkType: hard
+
 "type-fest@npm:^4.21.0":
   version: 4.41.0
   resolution: "type-fest@npm:4.41.0"
@@ -4421,6 +5399,21 @@ __metadata:
   dependencies:
     semver: "npm:^7.3.8"
   checksum: 10c0/aad48d6aa9985f9a056c5c89ab91b6781c5430c0b80652586c2a997f2cc394f3ed70ec18c0c818a8423991a1cfe7e64d010cc2fded9ea192067a3188476c2b51
+  languageName: node
+  linkType: hard
+
+"typescript-eslint@npm:^8.56.0":
+  version: 8.56.0
+  resolution: "typescript-eslint@npm:8.56.0"
+  dependencies:
+    "@typescript-eslint/eslint-plugin": "npm:8.56.0"
+    "@typescript-eslint/parser": "npm:8.56.0"
+    "@typescript-eslint/typescript-estree": "npm:8.56.0"
+    "@typescript-eslint/utils": "npm:8.56.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 10c0/13c47bb4a82d6714d482e96991faf2895c45a8e74235191a2ebbd36272487595c0824d128958942a1d1d18eddf8ca40c5850e2e314958a0a2e3c40be92f2d5a0
   languageName: node
   linkType: hard
 
@@ -4675,6 +5668,22 @@ __metadata:
     uploadthing:
       optional: true
   checksum: 10c0/200e9f8e26545b7e1db5c91941d211d2e27f54d3615d746a5c9ee8294bdfdbbb6d7c50478a8a0ce45920eaae1d07429b3f5754e1c87f2e740f40fe3ae5da94a2
+  languageName: node
+  linkType: hard
+
+"uri-js@npm:^4.2.2":
+  version: 4.4.1
+  resolution: "uri-js@npm:4.4.1"
+  dependencies:
+    punycode: "npm:^2.1.0"
+  checksum: 10c0/4ef57b45aa820d7ac6496e9208559986c665e49447cb072744c13b66925a362d96dd5a46c4530a6b8e203e5db5fe849369444440cb22ecfc26c679359e5dfa3c
+  languageName: node
+  linkType: hard
+
+"util-deprecate@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "util-deprecate@npm:1.0.2"
+  checksum: 10c0/41a5bdd214df2f6c3ecf8622745e4a366c4adced864bc3c833739791aeeeb1838119af7daed4ba36428114b5c67dcda034a79c882e97e43c03e66a4dd7389942
   languageName: node
   linkType: hard
 
@@ -4996,6 +6005,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"which@npm:^2.0.1":
+  version: 2.0.2
+  resolution: "which@npm:2.0.2"
+  dependencies:
+    isexe: "npm:^2.0.0"
+  bin:
+    node-which: ./bin/node-which
+  checksum: 10c0/66522872a768b60c2a65a57e8ad184e5372f5b6a9ca6d5f033d4b0dc98aff63995655a7503b9c0a2598936f532120e81dd8cc155e2e92ed662a2b9377cc4374f
+  languageName: node
+  linkType: hard
+
 "which@npm:^6.0.0":
   version: 6.0.1
   resolution: "which@npm:6.0.1"
@@ -5013,6 +6033,13 @@ __metadata:
   dependencies:
     string-width: "npm:^7.0.0"
   checksum: 10c0/6bd6cca8cda502ef50e05353fd25de0df8c704ffc43ada7e0a9cf9a5d4f4e12520485d80e0b77cec8a21f6c3909042fcf732aa9281e5dbb98cc9384a138b2578
+  languageName: node
+  linkType: hard
+
+"word-wrap@npm:^1.2.5":
+  version: 1.2.5
+  resolution: "word-wrap@npm:1.2.5"
+  checksum: 10c0/e0e4a1ca27599c92a6ca4c32260e8a92e8a44f4ef6ef93f803f8ed823f486e0889fc0b93be4db59c8d51b3064951d25e43d434e95dc8c960cc3a63d65d00ba20
   languageName: node
   linkType: hard
 
@@ -5125,6 +6152,13 @@ __metadata:
     y18n: "npm:^5.0.5"
     yargs-parser: "npm:^21.1.1"
   checksum: 10c0/ccd7e723e61ad5965fffbb791366db689572b80cca80e0f96aad968dfff4156cd7cd1ad18607afe1046d8241e6fb2d6c08bf7fa7bfb5eaec818735d8feac8f05
+  languageName: node
+  linkType: hard
+
+"yocto-queue@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "yocto-queue@npm:0.1.0"
+  checksum: 10c0/dceb44c28578b31641e13695d200d34ec4ab3966a5729814d5445b194933c096b7ced71494ce53a0e8820685d1d010df8b2422e5bf2cdea7e469d97ffbea306f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Add ESLint (flat config) with `typescript-eslint`, `eslint-plugin-astro`, and `eslint-config-prettier`
- Add Prettier with `prettier-plugin-astro` for consistent formatting across `.ts`, `.astro`, and `.md` files
- Add VSCode workspace settings: format-on-save, default formatters, extension recommendations
- Add `lint`, `lint:fix`, `format`, and `format:check` scripts to `package.json`
- Add `format:check` and `lint` steps to CI workflow (before `astro check`)
- Switch to `nodeLinker: node-modules` to work around Yarn PnP/pnpm plugin resolution issues ([yarnpkg/berry#6167](https://github.com/yarnpkg/berry/issues/6167), [yarnpkg/berry#6219](https://github.com/yarnpkg/berry/issues/6219))
- Fix invalid HTML comment inside JSX expression in `Sidebar.astro`
- Auto-format all existing source files with Prettier

## Test plan

- [ ] `yarn format:check` passes
- [ ] `yarn lint` passes
- [ ] `yarn build` succeeds
- [ ] CI workflow passes with new lint/format steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)